### PR TITLE
use the current version of the book for trait doc

### DIFF
--- a/src/01_setup.md
+++ b/src/01_setup.md
@@ -98,7 +98,7 @@ A trait is much like an interface in other languages, it allows us to associate 
 {{#include ../code/rust-sokoban-01/src/main.rs:9:23}}
 ```
 
-> **_MORE:_**  Read more about traits [here](https://doc.rust-lang.org/1.30.0/book/2018-edition/ch10-02-traits.html).
+> **_MORE:_**  Read more about traits [here](https://doc.rust-lang.org/book/ch10-02-traits.html).
 
 
 ### Functions


### PR DESCRIPTION
Probably what you meant according to other links to the official rust book. But could lead to dead links in the future while the official documentation evolve.