### PR TITLE
Run `cargo --fix` against the codebase

### DIFF
--- a/code/rust-sokoban-c01-03/src/main.rs
+++ b/code/rust-sokoban-c01-03/src/main.rs
@@ -1,8 +1,3 @@
-use ggez;
-use ggez::graphics;
-use ggez::graphics::DrawParam;
-use ggez::graphics::Image;
-use ggez::nalgebra as na;
 use ggez::{conf, event, Context, GameResult};
 use specs::{
     join::Join, Builder, Component, ReadStorage, RunNow, System, VecStorage, World, WorldExt,
@@ -53,7 +48,7 @@ impl event::EventHandler for Game {
         Ok(())
     }
 
-    fn draw(&mut self, context: &mut Context) -> GameResult {
+    fn draw(&mut self, _context: &mut Context) -> GameResult {
         Ok(())
     }
 }

--- a/code/rust-sokoban-c01-04/src/main.rs
+++ b/code/rust-sokoban-c01-04/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::graphics;
 use ggez::graphics::DrawParam;
 use ggez::graphics::Image;

--- a/code/rust-sokoban-c02-01/src/main.rs
+++ b/code/rust-sokoban-c02-01/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::graphics;
 use ggez::graphics::DrawParam;
 use ggez::graphics::Image;
@@ -177,7 +176,7 @@ pub fn create_player(world: &mut World, position: Position) {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . B . . W

--- a/code/rust-sokoban-c02-02/src/main.rs
+++ b/code/rust-sokoban-c02-02/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::event::{KeyCode, KeyMods};
 use ggez::graphics;
 use ggez::graphics::DrawParam;
@@ -6,7 +5,7 @@ use ggez::graphics::Image;
 use ggez::nalgebra as na;
 use ggez::{conf, event, Context, GameResult};
 use specs::{
-    join::Join, Builder, Component, Read, ReadStorage, RunNow, System, VecStorage, World, WorldExt,
+    join::Join, Builder, Component, ReadStorage, RunNow, System, VecStorage, World, WorldExt,
     Write, WriteStorage,
 };
 
@@ -237,7 +236,7 @@ pub fn create_player(world: &mut World, position: Position) {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . B . . W

--- a/code/rust-sokoban-c02-03/src/main.rs
+++ b/code/rust-sokoban-c02-03/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
 use ggez::graphics;
@@ -11,8 +10,7 @@ use specs::Entities;
 use specs::NullStorage;
 use specs::WriteStorage;
 use specs::{
-    join::Join, Builder, Component, Read, ReadStorage, RunNow, System, VecStorage, World, WorldExt,
-    Write,
+    join::Join, Builder, Component, ReadStorage, RunNow, System, VecStorage, World, WorldExt, Write,
 };
 use std::collections::HashMap;
 use std::path;
@@ -129,13 +127,13 @@ impl<'a> System<'a> for InputSystem {
             // Get the first key pressed
             if let Some(key) = input_queue.keys_pressed.pop() {
                 // get all the movables and immovables
-                let mut mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
+                let mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
                     .collect::<Vec<_>>()
                     .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
-                let mut immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
+                let immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
                     .collect::<Vec<_>>()
                     .into_iter()
@@ -175,7 +173,7 @@ impl<'a> System<'a> for InputSystem {
                             // if it exists, we need to stop and not move anything
                             // if it doesn't exist, we stop because we found a gap
                             match immov.get(&pos) {
-                                Some(id) => to_move.clear(),
+                                Some(_id) => to_move.clear(),
                                 None => break,
                             }
                         }
@@ -322,7 +320,7 @@ pub fn create_player(world: &mut World, position: Position) {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . B . . W

--- a/code/rust-sokoban-c02-04/src/main.rs
+++ b/code/rust-sokoban-c02-04/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
 use ggez::{conf, event, Context, GameResult};
@@ -58,7 +57,7 @@ impl event::EventHandler for Game {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . B . . W

--- a/code/rust-sokoban-c02-05/src/main.rs
+++ b/code/rust-sokoban-c02-05/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
 use ggez::{conf, event, Context, GameResult};
@@ -64,7 +63,7 @@ impl event::EventHandler for Game {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . B . . W

--- a/code/rust-sokoban-c03-01/src/entities.rs
+++ b/code/rust-sokoban-c03-01/src/entities.rs
@@ -29,7 +29,7 @@ pub fn create_box(world: &mut World, position: Position, colour: BoxColour) {
         .create_entity()
         .with(Position { z: 10, ..position })
         .with(Renderable {
-            path: format!("/images/box_{}.png", colour.to_string()).to_string(),
+            path: format!("/images/box_{}.png", colour.to_string()),
         })
         .with(Box { colour })
         .with(Movable)
@@ -41,7 +41,7 @@ pub fn create_box_spot(world: &mut World, position: Position, colour: BoxColour)
         .create_entity()
         .with(Position { z: 9, ..position })
         .with(Renderable {
-            path: format!("/images/box_spot_{}.png", colour.to_string()).to_string(),
+            path: format!("/images/box_spot_{}.png", colour.to_string()),
         })
         .with(BoxSpot { colour })
         .build();

--- a/code/rust-sokoban-c03-01/src/main.rs
+++ b/code/rust-sokoban-c03-01/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
 use ggez::{conf, event, Context, GameResult};
@@ -64,7 +63,7 @@ impl event::EventHandler for Game {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . BB . . W

--- a/code/rust-sokoban-c03-02/src/main.rs
+++ b/code/rust-sokoban-c03-02/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
 use ggez::{conf, event, timer, Context, GameResult};
@@ -70,7 +69,7 @@ impl event::EventHandler for Game {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . BB . . W

--- a/code/rust-sokoban-c03-03/src/main.rs
+++ b/code/rust-sokoban-c03-03/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
 use ggez::{conf, event, timer, Context, GameResult};
@@ -79,7 +78,7 @@ impl event::EventHandler for Game {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . BB . . W

--- a/code/rust-sokoban-c03-04/src/main.rs
+++ b/code/rust-sokoban-c03-04/src/main.rs
@@ -1,4 +1,3 @@
-use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
 use ggez::{conf, event, timer, Context, GameResult};
@@ -79,7 +78,7 @@ impl event::EventHandler for Game {
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
-    const MAP: &'static str = "
+    const MAP: &str = "
     N N W W W W W W
     W W W . . . . W
     W . . . BB . . W


### PR DESCRIPTION
I was thinking to extend the pipeline with clippy action (https://github.com/actions-rs/clippy-check), so we can automatically follow the rust guidelines. As a preparation for that I ran a fixer (cargo --fix) for all the projects.
One obvious downside to the fixes removing lines is that the book is using line numbers currently, so those will be affected.

I was reading through mdbook docs and stumbled upon anchors in there, would it be an idea to replace line numbers with those? See (https://rust-lang.github.io/mdBook/format/mdbook.html?highlight=ANCHOR#including-portions-of-a-file). That should make the book quite resilient to even rather big refactorings. 

@iolivia what do you think?
  