### PR TITLE
Add book title

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,4 +1,5 @@
 [book]
+title = "Rust sokoban"
 authors = []
 language = "en"
 multilingual = false


### PR DESCRIPTION
Fixes an issue when book title is not displayed in the browser tab.

That's how the tab title is currently rendered:
![image](https://user-images.githubusercontent.com/6346442/87141982-233f5680-c2a4-11ea-931e-ef7dda273178.png)

Seems like we're missing the `title` attribute in the book definition.

That's how it looks with the fix
![image](https://user-images.githubusercontent.com/6346442/87142165-71545a00-c2a4-11ea-9636-fdfff6c27dd3.png)
