### PR TITLE
breaking out event_system into multiple event_handler systems

### DIFF
--- a/code/rust-sokoban-c03-05/Cargo.toml
+++ b/code/rust-sokoban-c03-05/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-cargo-features = ["unstable"]
-
 [dependencies]
 ggez = "0.5.1"
 specs = { version = "0.15.0", features = ["specs-derive"] }

--- a/code/rust-sokoban-c03-05/Cargo.toml
+++ b/code/rust-sokoban-c03-05/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+cargo-features = ["unstable"]
+
 [dependencies]
 ggez = "0.5.1"
 specs = { version = "0.15.0", features = ["specs-derive"] }

--- a/code/rust-sokoban-c03-05/src/main.rs
+++ b/code/rust-sokoban-c03-05/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(drain_filter)]
 use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
@@ -44,9 +45,17 @@ impl event::EventHandler for Game {
             time.delta += timer::delta(context);
         }
 
-        // Run event system
+        // Run event_handler system
         {
-            let mut es = EventSystem {};
+            let mut es = box_placed_on_spot_event_handler_system::EventHandlerSystem {};
+            es.run_now(&self.world);
+        }
+        {
+            let mut es = player_hit_obstacle_event_handler_system::EventHandlerSystem {};
+            es.run_now(&self.world);
+        }
+        {
+            let mut es = entity_moved_event_handler_system::EventHandlerSystem {};
             es.run_now(&self.world);
         }
 

--- a/code/rust-sokoban-c03-05/src/main.rs
+++ b/code/rust-sokoban-c03-05/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(drain_filter)]
 use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
@@ -19,7 +18,12 @@ use crate::audio::*;
 use crate::components::*;
 use crate::map::*;
 use crate::resources::*;
-use crate::systems::*;
+use crate::systems::{
+    *,
+    box_placed_on_spot_event_handler_system as box_placed_on_spot,
+    entity_moved_event_handler_system as entity_moved,
+    player_hit_obstacle_event_handler_system as player_hit_obstacle,
+} ;
 
 struct Game {
     world: World,
@@ -47,15 +51,15 @@ impl event::EventHandler for Game {
 
         // Run event_handler system
         {
-            let mut es = box_placed_on_spot_event_handler_system::EventHandlerSystem {};
+            let mut es = box_placed_on_spot::EventHandlerSystem {};
             es.run_now(&self.world);
         }
         {
-            let mut es = player_hit_obstacle_event_handler_system::EventHandlerSystem {};
+            let mut es = player_hit_obstacle::EventHandlerSystem {};
             es.run_now(&self.world);
         }
         {
-            let mut es = entity_moved_event_handler_system::EventHandlerSystem {};
+            let mut es = entity_moved::EventHandlerSystem {};
             es.run_now(&self.world);
         }
 

--- a/code/rust-sokoban-c03-05/src/systems/box_placed_on_spot_event_handler_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/box_placed_on_spot_event_handler_system.rs
@@ -11,32 +11,34 @@ pub struct EventHandlerSystem {}
 impl<'a> System<'a> for EventHandlerSystem {
     // Data
     type SystemData = (
-        Read<'a, EventQueue>,
+        Write<'a, EventQueue>,
         Write<'a, AudioStore>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (event_queue, mut audio_store) = data;
+        let (mut event_queue, mut audio_store) = data;
 
+        let mut new_events = Vec::new();
         event_queue.events
-            .iter()
-            .filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
-            .collect::<Vec<_>>()
             .drain(..)
             .for_each(|event| {
+                println!("box_placed: {:?}", event);
                 // play sound here
                 if let Event::BoxPlacedOnSpot(BoxPlacedOnSpot{ is_correct_spot }) = event {
-                    let sound = if *is_correct_spot {
+                    let sound = if is_correct_spot {
                         "correct"
                     } else {
                         "incorrect"
                     };
 
-                audio_store.play_sound(&sound.to_string())
+                    audio_store.play_sound(&sound.to_string())
 
+                } else {
+                    new_events.push(event);
                 }
 
             });
+        event_queue.events.append(&mut new_events);
         //event_queue.events
         //    .drain_filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
         //    .for_each(|event| {

--- a/code/rust-sokoban-c03-05/src/systems/box_placed_on_spot_event_handler_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/box_placed_on_spot_event_handler_system.rs
@@ -3,7 +3,7 @@ use crate::{
     events::{BoxPlacedOnSpot, Event},
     resources::EventQueue,
 };
-use specs::{System, Write};
+use specs::{System, Write, Read};
 
 pub struct EventHandlerSystem {}
 
@@ -11,19 +11,22 @@ pub struct EventHandlerSystem {}
 impl<'a> System<'a> for EventHandlerSystem {
     // Data
     type SystemData = (
-        Write<'a, EventQueue>,
+        Read<'a, EventQueue>,
         Write<'a, AudioStore>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (mut event_queue, mut audio_store) = data;
+        let (event_queue, mut audio_store) = data;
 
         event_queue.events
-            .drain_filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
+            .iter()
+            .filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
+            .collect::<Vec<_>>()
+            .drain(..)
             .for_each(|event| {
                 // play sound here
                 if let Event::BoxPlacedOnSpot(BoxPlacedOnSpot{ is_correct_spot }) = event {
-                    let sound = if is_correct_spot {
+                    let sound = if *is_correct_spot {
                         "correct"
                     } else {
                         "incorrect"
@@ -34,5 +37,21 @@ impl<'a> System<'a> for EventHandlerSystem {
                 }
 
             });
+        //event_queue.events
+        //    .drain_filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
+        //    .for_each(|event| {
+        //        // play sound here
+        //        if let Event::BoxPlacedOnSpot(BoxPlacedOnSpot{ is_correct_spot }) = event {
+        //            let sound = if is_correct_spot {
+        //                "correct"
+        //            } else {
+        //                "incorrect"
+        //            };
+
+        //        audio_store.play_sound(&sound.to_string())
+
+        //        }
+
+        //    });
     }
 }

--- a/code/rust-sokoban-c03-05/src/systems/box_placed_on_spot_event_handler_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/box_placed_on_spot_event_handler_system.rs
@@ -1,0 +1,38 @@
+use crate::{
+    audio::AudioStore,
+    events::{BoxPlacedOnSpot, Event},
+    resources::EventQueue,
+};
+use specs::{System, Write};
+
+pub struct EventHandlerSystem {}
+
+// System implementation
+impl<'a> System<'a> for EventHandlerSystem {
+    // Data
+    type SystemData = (
+        Write<'a, EventQueue>,
+        Write<'a, AudioStore>,
+    );
+
+    fn run(&mut self, data: Self::SystemData) {
+        let (mut event_queue, mut audio_store) = data;
+
+        event_queue.events
+            .drain_filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
+            .for_each(|event| {
+                // play sound here
+                if let Event::BoxPlacedOnSpot(BoxPlacedOnSpot{ is_correct_spot }) = event {
+                    let sound = if is_correct_spot {
+                        "correct"
+                    } else {
+                        "incorrect"
+                    };
+
+                audio_store.play_sound(&sound.to_string())
+
+                }
+
+            });
+    }
+}

--- a/code/rust-sokoban-c03-05/src/systems/entity_moved_event_handler_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/entity_moved_event_handler_system.rs
@@ -24,15 +24,13 @@ impl<'a> System<'a> for EventHandlerSystem {
 
         let mut new_events = Vec::new();
         event_queue.events
-            .iter()
-            .filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
-            .collect::<Vec<_>>()
             .drain(..)
             .for_each(|event| {
+                println!("entity moved {:?}", event);
                 if let Event::EntityMoved(EntityMoved{ id }) = event {
                     // An entity was just moved, check if it was a box and fire
                     // more events if it's been moved on a spot.
-                    if let Some(the_box) = boxes.get(entities.entity(*id)) {
+                    if let Some(the_box) = boxes.get(entities.entity(id)) {
                         let box_spots_with_positions: HashMap<(u8, u8), &BoxSpot> =
                             (&box_spots, &positions)
                                 .join()
@@ -41,7 +39,7 @@ impl<'a> System<'a> for EventHandlerSystem {
                                 .map(|t| ((t.1.x, t.1.y), t.0))
                                 .collect::<HashMap<_, _>>();
 
-                        if let Some(box_position) = positions.get(entities.entity(*id)) {
+                        if let Some(box_position) = positions.get(entities.entity(id)) {
                             // Check if there is a spot on this position, and if there
                             // is if it's the correct or incorrect type
                             if let Some(box_spot) =
@@ -53,7 +51,8 @@ impl<'a> System<'a> for EventHandlerSystem {
                             }
                         }
                     }
-
+                } else {
+                    new_events.push(event);
                 }
             });
         //event_queue.events

--- a/code/rust-sokoban-c03-05/src/systems/entity_moved_event_handler_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/entity_moved_event_handler_system.rs
@@ -24,12 +24,15 @@ impl<'a> System<'a> for EventHandlerSystem {
 
         let mut new_events = Vec::new();
         event_queue.events
-            .drain_filter(|x| matches!(x, Event::EntityMoved(_)))
+            .iter()
+            .filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
+            .collect::<Vec<_>>()
+            .drain(..)
             .for_each(|event| {
                 if let Event::EntityMoved(EntityMoved{ id }) = event {
                     // An entity was just moved, check if it was a box and fire
                     // more events if it's been moved on a spot.
-                    if let Some(the_box) = boxes.get(entities.entity(id)) {
+                    if let Some(the_box) = boxes.get(entities.entity(*id)) {
                         let box_spots_with_positions: HashMap<(u8, u8), &BoxSpot> =
                             (&box_spots, &positions)
                                 .join()
@@ -38,7 +41,7 @@ impl<'a> System<'a> for EventHandlerSystem {
                                 .map(|t| ((t.1.x, t.1.y), t.0))
                                 .collect::<HashMap<_, _>>();
 
-                        if let Some(box_position) = positions.get(entities.entity(id)) {
+                        if let Some(box_position) = positions.get(entities.entity(*id)) {
                             // Check if there is a spot on this position, and if there
                             // is if it's the correct or incorrect type
                             if let Some(box_spot) =
@@ -53,6 +56,36 @@ impl<'a> System<'a> for EventHandlerSystem {
 
                 }
             });
+        //event_queue.events
+        //    .drain_filter(|x| matches!(x, Event::EntityMoved(_)))
+        //    .for_each(|event| {
+        //        if let Event::EntityMoved(EntityMoved{ id }) = event {
+        //            // An entity was just moved, check if it was a box and fire
+        //            // more events if it's been moved on a spot.
+        //            if let Some(the_box) = boxes.get(entities.entity(id)) {
+        //                let box_spots_with_positions: HashMap<(u8, u8), &BoxSpot> =
+        //                    (&box_spots, &positions)
+        //                        .join()
+        //                        .collect::<Vec<_>>()
+        //                        .into_iter()
+        //                        .map(|t| ((t.1.x, t.1.y), t.0))
+        //                        .collect::<HashMap<_, _>>();
+
+        //                if let Some(box_position) = positions.get(entities.entity(id)) {
+        //                    // Check if there is a spot on this position, and if there
+        //                    // is if it's the correct or incorrect type
+        //                    if let Some(box_spot) =
+        //                        box_spots_with_positions.get(&(box_position.x, box_position.y))
+        //                    {
+        //                        new_events.push(Event::BoxPlacedOnSpot(BoxPlacedOnSpot {
+        //                            is_correct_spot: (box_spot.colour == the_box.colour),
+        //                        }));
+        //                    }
+        //                }
+        //            }
+
+        //        }
+        //    });
 
         event_queue.events.append(&mut new_events);
     }

--- a/code/rust-sokoban-c03-05/src/systems/mod.rs
+++ b/code/rust-sokoban-c03-05/src/systems/mod.rs
@@ -1,9 +1,10 @@
-mod event_system;
 mod gameplay_state_system;
 mod input_system;
 mod rendering_system;
+pub mod box_placed_on_spot_event_handler_system;
+pub mod player_hit_obstacle_event_handler_system;
+pub mod entity_moved_event_handler_system;
 
-pub use self::event_system::EventSystem;
 pub use self::gameplay_state_system::GameplayStateSystem;
 pub use self::input_system::InputSystem;
 pub use self::rendering_system::RenderingSystem;

--- a/code/rust-sokoban-c03-05/src/systems/mod.rs
+++ b/code/rust-sokoban-c03-05/src/systems/mod.rs
@@ -1,3 +1,4 @@
+
 mod gameplay_state_system;
 mod input_system;
 mod rendering_system;

--- a/code/rust-sokoban-c03-05/src/systems/player_hit_obstacle_event_handler_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/player_hit_obstacle_event_handler_system.rs
@@ -3,7 +3,7 @@ use crate::{
     events::{Event},
     resources::EventQueue,
 };
-use specs::{System, Write};
+use specs::{System, Write, Read};
 
 pub struct EventHandlerSystem {}
 
@@ -11,19 +11,29 @@ pub struct EventHandlerSystem {}
 impl<'a> System<'a> for EventHandlerSystem {
     // Data
     type SystemData = (
-        Write<'a, EventQueue>,
+        Read<'a, EventQueue>,
         Write<'a, AudioStore>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (mut event_queue, mut audio_store) = data;
+        let (event_queue, mut audio_store) = data;
 
         event_queue.events
-            .drain_filter(|x| matches!(x, Event::PlayerHitObstacle) )
+            .iter()
+            .filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
+            .collect::<Vec<_>>()
+            .drain(..)
             .for_each(|event| {
                 if let Event::PlayerHitObstacle = event {
                     audio_store.play_sound(&"wall".to_string());
                 }
             });
+        //event_queue.events
+        //    .drain_filter(|x| matches!(x, Event::PlayerHitObstacle) )
+        //    .for_each(|event| {
+        //        if let Event::PlayerHitObstacle = event {
+        //            audio_store.play_sound(&"wall".to_string());
+        //        }
+        //    });
     }
 }

--- a/code/rust-sokoban-c03-05/src/systems/player_hit_obstacle_event_handler_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/player_hit_obstacle_event_handler_system.rs
@@ -11,23 +11,25 @@ pub struct EventHandlerSystem {}
 impl<'a> System<'a> for EventHandlerSystem {
     // Data
     type SystemData = (
-        Read<'a, EventQueue>,
+        Write<'a, EventQueue>,
         Write<'a, AudioStore>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (event_queue, mut audio_store) = data;
+        let ( mut event_queue, mut audio_store) = data;
 
+        let mut new_events = Vec::new();
         event_queue.events
-            .iter()
-            .filter(|x| matches!(x, Event::BoxPlacedOnSpot(_)))
-            .collect::<Vec<_>>()
             .drain(..)
             .for_each(|event| {
+                println!("player hit {:?}", event);
                 if let Event::PlayerHitObstacle = event {
                     audio_store.play_sound(&"wall".to_string());
+                } else {
+                    new_events.push(event);
                 }
             });
+        event_queue.events.append(&mut new_events);
         //event_queue.events
         //    .drain_filter(|x| matches!(x, Event::PlayerHitObstacle) )
         //    .for_each(|event| {

--- a/code/rust-sokoban-c03-05/src/systems/player_hit_obstacle_event_handler_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/player_hit_obstacle_event_handler_system.rs
@@ -1,0 +1,29 @@
+use crate::{
+    audio::AudioStore,
+    events::{Event},
+    resources::EventQueue,
+};
+use specs::{System, Write};
+
+pub struct EventHandlerSystem {}
+
+// System implementation
+impl<'a> System<'a> for EventHandlerSystem {
+    // Data
+    type SystemData = (
+        Write<'a, EventQueue>,
+        Write<'a, AudioStore>,
+    );
+
+    fn run(&mut self, data: Self::SystemData) {
+        let (mut event_queue, mut audio_store) = data;
+
+        event_queue.events
+            .drain_filter(|x| matches!(x, Event::PlayerHitObstacle) )
+            .for_each(|event| {
+                if let Event::PlayerHitObstacle = event {
+                    audio_store.play_sound(&"wall".to_string());
+                }
+            });
+    }
+}


### PR DESCRIPTION
Hey,

I took the event_queue pattern and broke it out into multiple systems to handle each enum variant. 
I'm doing this in my current project and it looks something like this.

I did have to use the unstable feature `drain_filter` so that the event_queue would only have the matched enums removed. 

I didn't know where to put the refactor so i just threw it into the last chapter. 
Also, please excuse the poor naming of the systems. 

This is more a conversation-starter PR but this pattern works nicely for me. 
I didn't like dumping so much logic into a single EventSystem.
There is probably some way to avoid matching twice in each event handler system. 