### PR TITLE
Remove unnecessary `to_string` calls

### DIFF
--- a/code/rust-sokoban-c03-01/src/entities.rs
+++ b/code/rust-sokoban-c03-01/src/entities.rs
@@ -29,7 +29,7 @@ pub fn create_box(world: &mut World, position: Position, colour: BoxColour) {
         .create_entity()
         .with(Position { z: 10, ..position })
         .with(Renderable {
-            path: format!("/images/box_{}.png", colour.to_string()).to_string(),
+            path: format!("/images/box_{}.png", colour),
         })
         .with(Box { colour })
         .with(Movable)
@@ -41,7 +41,7 @@ pub fn create_box_spot(world: &mut World, position: Position, colour: BoxColour)
         .create_entity()
         .with(Position { z: 9, ..position })
         .with(Renderable {
-            path: format!("/images/box_spot_{}.png", colour.to_string()).to_string(),
+            path: format!("/images/box_spot_{}.png", colour),
         })
         .with(BoxSpot { colour })
         .build();

--- a/code/rust-sokoban-c03-02/src/entities.rs
+++ b/code/rust-sokoban-c03-02/src/entities.rs
@@ -25,8 +25,8 @@ pub fn create_box(world: &mut World, position: Position, colour: BoxColour) {
         .create_entity()
         .with(Position { z: 10, ..position })
         .with(Renderable::new_animated(vec![
-            format!("/images/box_{}_1.png", colour.to_string()),
-            format!("/images/box_{}_2.png", colour.to_string()),
+            format!("/images/box_{}_1.png", colour),
+            format!("/images/box_{}_2.png", colour),
         ]))
         .with(Box { colour })
         .with(Movable)
@@ -39,7 +39,7 @@ pub fn create_box_spot(world: &mut World, position: Position, colour: BoxColour)
         .with(Position { z: 9, ..position })
         .with(Renderable::new_static(format!(
             "/images/box_spot_{}.png",
-            colour.to_string()
+            colour
         )))
         .with(BoxSpot { colour })
         .build();

--- a/code/rust-sokoban-c03-03/src/audio.rs
+++ b/code/rust-sokoban-c03-03/src/audio.rs
@@ -24,7 +24,7 @@ pub fn initialize_sounds(world: &mut World, context: &mut Context) {
 
     for sound in sounds.iter() {
         let sound_name = sound.to_string();
-        let sound_path = format!("/sounds/{}.wav", sound_name).to_string();
+        let sound_path = format!("/sounds/{}.wav", sound_name);
         let sound_source = audio::Source::new(context, sound_path).expect("expected sound loaded");
 
         audio_store.sounds.insert(sound_name, sound_source);

--- a/code/rust-sokoban-c03-03/src/entities.rs
+++ b/code/rust-sokoban-c03-03/src/entities.rs
@@ -25,8 +25,8 @@ pub fn create_box(world: &mut World, position: Position, colour: BoxColour) {
         .create_entity()
         .with(Position { z: 10, ..position })
         .with(Renderable::new_animated(vec![
-            format!("/images/box_{}_1.png", colour.to_string()),
-            format!("/images/box_{}_2.png", colour.to_string()),
+            format!("/images/box_{}_1.png", colour),
+            format!("/images/box_{}_2.png", colour),
         ]))
         .with(Box { colour })
         .with(Movable)
@@ -39,7 +39,7 @@ pub fn create_box_spot(world: &mut World, position: Position, colour: BoxColour)
         .with(Position { z: 9, ..position })
         .with(Renderable::new_static(format!(
             "/images/box_spot_{}.png",
-            colour.to_string()
+            colour
         )))
         .with(BoxSpot { colour })
         .build();

--- a/code/rust-sokoban-c03-04/src/audio.rs
+++ b/code/rust-sokoban-c03-04/src/audio.rs
@@ -24,7 +24,7 @@ pub fn initialize_sounds(world: &mut World, context: &mut Context) {
 
     for sound in sounds.iter() {
         let sound_name = sound.to_string();
-        let sound_path = format!("/sounds/{}.wav", sound_name).to_string();
+        let sound_path = format!("/sounds/{}.wav", sound_name);
         let sound_source = audio::Source::new(context, sound_path).expect("expected sound loaded");
 
         audio_store.sounds.insert(sound_name, sound_source);

--- a/code/rust-sokoban-c03-04/src/entities.rs
+++ b/code/rust-sokoban-c03-04/src/entities.rs
@@ -25,8 +25,8 @@ pub fn create_box(world: &mut World, position: Position, colour: BoxColour) {
         .create_entity()
         .with(Position { z: 10, ..position })
         .with(Renderable::new_animated(vec![
-            format!("/images/box_{}_1.png", colour.to_string()),
-            format!("/images/box_{}_2.png", colour.to_string()),
+            format!("/images/box_{}_1.png", colour),
+            format!("/images/box_{}_2.png", colour),
         ]))
         .with(Box { colour })
         .with(Movable)
@@ -39,7 +39,7 @@ pub fn create_box_spot(world: &mut World, position: Position, colour: BoxColour)
         .with(Position { z: 9, ..position })
         .with(Renderable::new_static(format!(
             "/images/box_spot_{}.png",
-            colour.to_string()
+            colour
         )))
         .with(BoxSpot { colour })
         .build();

--- a/code/rust-sokoban-c03-05/src/audio.rs
+++ b/code/rust-sokoban-c03-05/src/audio.rs
@@ -24,7 +24,7 @@ pub fn initialize_sounds(world: &mut World, context: &mut Context) {
 
     for sound in sounds.iter() {
         let sound_name = sound.to_string();
-        let sound_path = format!("/sounds/{}.wav", sound_name).to_string();
+        let sound_path = format!("/sounds/{}.wav", sound_name);
         let sound_source = audio::Source::new(context, sound_path).expect("expected sound loaded");
 
         audio_store.sounds.insert(sound_name, sound_source);

--- a/code/rust-sokoban-c03-05/src/entities.rs
+++ b/code/rust-sokoban-c03-05/src/entities.rs
@@ -25,8 +25,8 @@ pub fn create_box(world: &mut World, position: Position, colour: BoxColour) {
         .create_entity()
         .with(Position { z: 10, ..position })
         .with(Renderable::new_animated(vec![
-            format!("/images/box_{}_1.png", colour.to_string()),
-            format!("/images/box_{}_2.png", colour.to_string()),
+            format!("/images/box_{}_1.png", colour),
+            format!("/images/box_{}_2.png", colour),
         ]))
         .with(Box { colour })
         .with(Movable)
@@ -39,7 +39,7 @@ pub fn create_box_spot(world: &mut World, position: Position, colour: BoxColour)
         .with(Position { z: 9, ..position })
         .with(Renderable::new_static(format!(
             "/images/box_spot_{}.png",
-            colour.to_string()
+            colour
         )))
         .with(BoxSpot { colour })
         .build();


### PR DESCRIPTION
Since `format!` returns a string, there is no reason to call
`format!().to_string()`.

Also, since the `"{}"` formatting specifier calls `.to_string()` on it's
argument, there is no reason to call `.to_string()` on the argument
ourselves.