### PR TITLE
Remove unnecessary allocation of a Vec

### DIFF
--- a/code/rust-sokoban-c02-03/src/main.rs
+++ b/code/rust-sokoban-c02-03/src/main.rs
@@ -131,14 +131,10 @@ impl<'a> System<'a> for InputSystem {
                 // get all the movables and immovables
                 let mut mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
                 let mut immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c02-04/src/systems/input_system.rs
+++ b/code/rust-sokoban-c02-04/src/systems/input_system.rs
@@ -31,14 +31,10 @@ impl<'a> System<'a> for InputSystem {
                 // get all the movables and immovables
                 let mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
                 let immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c02-05/src/systems/gameplay_state_system.rs
+++ b/code/rust-sokoban-c02-05/src/systems/gameplay_state_system.rs
@@ -23,8 +23,6 @@ impl<'a> System<'a> for GameplayStateSystem {
         // get all boxes indexed by position
         let boxes_by_position: HashMap<(u8, u8), &Box> = (&positions, &boxes)
             .join()
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(|t| ((t.0.x, t.0.y), t.1))
             .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c02-05/src/systems/input_system.rs
+++ b/code/rust-sokoban-c02-05/src/systems/input_system.rs
@@ -32,14 +32,10 @@ impl<'a> System<'a> for InputSystem {
                 // get all the movables and immovables
                 let mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
                 let immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-01/src/systems/gameplay_state_system.rs
+++ b/code/rust-sokoban-c03-01/src/systems/gameplay_state_system.rs
@@ -23,8 +23,6 @@ impl<'a> System<'a> for GameplayStateSystem {
         // get all boxes indexed by position
         let boxes_by_position: HashMap<(u8, u8), &Box> = (&positions, &boxes)
             .join()
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(|t| ((t.0.x, t.0.y), t.1))
             .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-01/src/systems/input_system.rs
+++ b/code/rust-sokoban-c03-01/src/systems/input_system.rs
@@ -32,14 +32,10 @@ impl<'a> System<'a> for InputSystem {
                 // get all the movables and immovables
                 let mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
                 let immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-02/src/systems/gameplay_state_system.rs
+++ b/code/rust-sokoban-c03-02/src/systems/gameplay_state_system.rs
@@ -23,8 +23,6 @@ impl<'a> System<'a> for GameplayStateSystem {
         // get all boxes indexed by position
         let boxes_by_position: HashMap<(u8, u8), &Box> = (&positions, &boxes)
             .join()
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(|t| ((t.0.x, t.0.y), t.1))
             .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-02/src/systems/input_system.rs
+++ b/code/rust-sokoban-c03-02/src/systems/input_system.rs
@@ -32,14 +32,10 @@ impl<'a> System<'a> for InputSystem {
                 // get all the movables and immovables
                 let mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
                 let immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-03/src/systems/event_system.rs
+++ b/code/rust-sokoban-c03-03/src/systems/event_system.rs
@@ -41,8 +41,6 @@ impl<'a> System<'a> for EventSystem {
                         let box_spots_with_positions: HashMap<(u8, u8), &BoxSpot> =
                             (&box_spots, &positions)
                                 .join()
-                                .collect::<Vec<_>>()
-                                .into_iter()
                                 .map(|t| ((t.1.x, t.1.y), t.0))
                                 .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-03/src/systems/gameplay_state_system.rs
+++ b/code/rust-sokoban-c03-03/src/systems/gameplay_state_system.rs
@@ -23,8 +23,6 @@ impl<'a> System<'a> for GameplayStateSystem {
         // get all boxes indexed by position
         let boxes_by_position: HashMap<(u8, u8), &Box> = (&positions, &boxes)
             .join()
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(|t| ((t.0.x, t.0.y), t.1))
             .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-03/src/systems/input_system.rs
+++ b/code/rust-sokoban-c03-03/src/systems/input_system.rs
@@ -43,14 +43,10 @@ impl<'a> System<'a> for InputSystem {
                 // get all the movables and immovables
                 let mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
                 let immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-04/src/systems/event_system.rs
+++ b/code/rust-sokoban-c03-04/src/systems/event_system.rs
@@ -41,8 +41,6 @@ impl<'a> System<'a> for EventSystem {
                         let box_spots_with_positions: HashMap<(u8, u8), &BoxSpot> =
                             (&box_spots, &positions)
                                 .join()
-                                .collect::<Vec<_>>()
-                                .into_iter()
                                 .map(|t| ((t.1.x, t.1.y), t.0))
                                 .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-04/src/systems/gameplay_state_system.rs
+++ b/code/rust-sokoban-c03-04/src/systems/gameplay_state_system.rs
@@ -23,8 +23,6 @@ impl<'a> System<'a> for GameplayStateSystem {
         // get all boxes indexed by position
         let boxes_by_position: HashMap<(u8, u8), &Box> = (&positions, &boxes)
             .join()
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(|t| ((t.0.x, t.0.y), t.1))
             .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-04/src/systems/input_system.rs
+++ b/code/rust-sokoban-c03-04/src/systems/input_system.rs
@@ -43,14 +43,10 @@ impl<'a> System<'a> for InputSystem {
                 // get all the movables and immovables
                 let mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
                 let immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-05/src/systems/event_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/event_system.rs
@@ -41,8 +41,6 @@ impl<'a> System<'a> for EventSystem {
                         let box_spots_with_positions: HashMap<(u8, u8), &BoxSpot> =
                             (&box_spots, &positions)
                                 .join()
-                                .collect::<Vec<_>>()
-                                .into_iter()
                                 .map(|t| ((t.1.x, t.1.y), t.0))
                                 .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-05/src/systems/gameplay_state_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/gameplay_state_system.rs
@@ -23,8 +23,6 @@ impl<'a> System<'a> for GameplayStateSystem {
         // get all boxes indexed by position
         let boxes_by_position: HashMap<(u8, u8), &Box> = (&positions, &boxes)
             .join()
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(|t| ((t.0.x, t.0.y), t.1))
             .collect::<HashMap<_, _>>();
 

--- a/code/rust-sokoban-c03-05/src/systems/input_system.rs
+++ b/code/rust-sokoban-c03-05/src/systems/input_system.rs
@@ -43,14 +43,10 @@ impl<'a> System<'a> for InputSystem {
                 // get all the movables and immovables
                 let mov: HashMap<(u8, u8), Index> = (&entities, &movables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
                 let immov: HashMap<(u8, u8), Index> = (&entities, &immovables, &positions)
                     .join()
-                    .collect::<Vec<_>>()
-                    .into_iter()
                     .map(|t| ((t.2.x, t.2.y), t.0.id()))
                     .collect::<HashMap<_, _>>();
 

--- a/src/c02-03-push-box.md
+++ b/src/c02-03-push-box.md
@@ -55,7 +55,7 @@ So given this, let's start implementing this logic. Let's think about the logica
 Here is the new implementation of the input systems, it's a bit long but hopefully it makes sense.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-03/src/main.rs:113:201}}
+{{#include ../code/rust-sokoban-c02-03/src/main.rs:113:197}}
 ```
 
 Now if we run the code, we'll see it actually works! We can't go through walls anymore and we can push the box and it stops when it gets to the wall.


### PR DESCRIPTION
In `input_system.rs`, we are collecting into a Vec, converting it into
an iterator, and collecting again into a Hashmap. The initial collection
into the Vec is unnecessary and we can just collect directly into the
HashMap