### PR TITLE
Use Anchors for Code

### DIFF
--- a/code/rust-sokoban-c01-01/src/main.rs
+++ b/code/rust-sokoban-c01-01/src/main.rs
@@ -1,26 +1,35 @@
+// ANCHOR: all
+// ANCHOR: includes
 use ggez::{conf, event, Context, GameResult};
 use std::path;
+// ANCHOR_END: includes
 
+// ANCHOR: struct
 // This struct will hold all our game state
 // For now there is nothing to be held, but we'll add
 // things shortly.
 struct Game {}
+// ANCHOR_END: struct
 
+// ANCHOR: trait
 // This is the main event loop. ggez tells us to implement
 // two things:
 // - updating
 // - rendering
 impl event::EventHandler for Game {
+    // ANCHOR: functions
     fn update(&mut self, _context: &mut Context) -> GameResult {
         // TODO: update game logic here
         Ok(())
     }
+    // ANCHOR_END: functions
 
     fn draw(&mut self, _context: &mut Context) -> GameResult {
         // TODO: update draw here
         Ok(())
     }
 }
+// ANCHOR_END: trait
 
 pub fn main() -> GameResult {
     // Create a game context and event loop
@@ -35,3 +44,4 @@ pub fn main() -> GameResult {
     // Run the main event loop
     event::run(context, event_loop, game)
 }
+// ANCHOR_END: all

--- a/code/rust-sokoban-c01-03/Cargo.toml
+++ b/code/rust-sokoban-c01-03/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# ANCHOR: dependencies
 [dependencies]
 ggez = "0.5.1"
 specs = { version = "0.15.0", features = ["specs-derive"] }
+# ANCHOR_END: dependencies

--- a/code/rust-sokoban-c01-03/src/main.rs
+++ b/code/rust-sokoban-c01-03/src/main.rs
@@ -1,15 +1,15 @@
+// ANCHOR: all
+// ANCHOR: includes
 use ggez;
-use ggez::graphics;
-use ggez::graphics::DrawParam;
-use ggez::graphics::Image;
-use ggez::nalgebra as na;
 use ggez::{conf, event, Context, GameResult};
 use specs::{
-    join::Join, Builder, Component, ReadStorage, RunNow, System, VecStorage, World, WorldExt,
+    Builder, Component, VecStorage, World, WorldExt,
 };
 
 use std::path;
+// ANCHOR_END: includes
 
+// ANCHOR: components
 // Components
 #[derive(Debug, Component, Clone, Copy)]
 #[storage(VecStorage)]
@@ -40,6 +40,7 @@ pub struct Box {}
 #[derive(Component)]
 #[storage(VecStorage)]
 pub struct BoxSpot {}
+// ANCHOR_END: components
 
 // This struct will hold all our game state
 // For now there is nothing to be held, but we'll add
@@ -58,6 +59,7 @@ impl event::EventHandler for Game {
     }
 }
 
+// ANCHOR: register_components
 // Register components with the world
 pub fn register_components(world: &mut World) {
     world.register::<Position>();
@@ -67,7 +69,9 @@ pub fn register_components(world: &mut World) {
     world.register::<Box>();
     world.register::<BoxSpot>();
 }
+// ANCHOR_END: register_components
 
+// ANCHOR: entities
 // Create a wall entity
 pub fn create_wall(world: &mut World, position: Position) {
     world
@@ -122,6 +126,7 @@ pub fn create_player(world: &mut World, position: Position) {
         .with(Player {})
         .build();
 }
+// ANCHOR_END: entities
 
 pub fn main() -> GameResult {
     let mut world = World::new();
@@ -140,3 +145,4 @@ pub fn main() -> GameResult {
     // Run the main event loop
     event::run(context, event_loop, game)
 }
+// ANCHOR_END: all

--- a/code/rust-sokoban-c01-04/src/main.rs
+++ b/code/rust-sokoban-c01-04/src/main.rs
@@ -1,12 +1,17 @@
+// ANCHOR: all
 use ggez;
+// ANCHOR: includes
 use ggez::graphics;
 use ggez::graphics::DrawParam;
 use ggez::graphics::Image;
 use ggez::nalgebra as na;
+// ANCHOR_END: includes
 use ggez::{conf, event, Context, GameResult};
+// ANCHOR: specs_includes
 use specs::{
     join::Join, Builder, Component, ReadStorage, RunNow, System, VecStorage, World, WorldExt,
 };
+// ANCHOR_END: specs_includes
 
 use std::path;
 
@@ -43,17 +48,22 @@ pub struct Box {}
 #[storage(VecStorage)]
 pub struct BoxSpot {}
 
+// ANCHOR: render_struct
 // Systems
 pub struct RenderingSystem<'a> {
     context: &'a mut Context,
 }
+// ANCHOR_END: render_struct
 
+// ANCHOR: render_impl_1
 // System implementation
 impl<'a> System<'a> for RenderingSystem<'a> {
     // Data
     type SystemData = (ReadStorage<'a, Position>, ReadStorage<'a, Renderable>);
 
+    // ANCHOR: render_run
     fn run(&mut self, data: Self::SystemData) {
+        // ANCHOR_END: render_impl_1
         let (positions, renderables) = data;
 
         // Clearing the screen (this gives us the backround colour)
@@ -80,8 +90,11 @@ impl<'a> System<'a> for RenderingSystem<'a> {
         // Finally, present the context, this will actually display everything
         // on the screen.
         graphics::present(self.context).expect("expected to present");
+        // ANCHOR: render_impl_2
     }
+    //ANCHOR_END: render_run
 }
+// ANCHOR_END: render_impl_2
 
 // This struct will hold all our game state
 // For now there is nothing to be held, but we'll add
@@ -94,6 +107,7 @@ struct Game {
 // two things:
 // - updating
 // - rendering
+// ANCHOR: event_handler
 impl event::EventHandler for Game {
     fn update(&mut self, _context: &mut Context) -> GameResult {
         Ok(())
@@ -109,6 +123,7 @@ impl event::EventHandler for Game {
         Ok(())
     }
 }
+// ANCHOR_END: event_handler
 
 // Register components with the world
 pub fn register_components(world: &mut World) {
@@ -175,6 +190,7 @@ pub fn create_player(world: &mut World, position: Position) {
         .build();
 }
 
+// ANCHOR: init_level
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
     create_player(
@@ -202,6 +218,7 @@ pub fn initialize_level(world: &mut World) {
         },
     );
 }
+// ANCHOR_END: init_level
 
 pub fn main() -> GameResult {
     let mut world = World::new();
@@ -221,3 +238,4 @@ pub fn main() -> GameResult {
     // Run the main event loop
     event::run(context, event_loop, game)
 }
+// ANCHOR_END: all

--- a/code/rust-sokoban-c02-01/src/main.rs
+++ b/code/rust-sokoban-c02-01/src/main.rs
@@ -1,3 +1,5 @@
+// ANCHOR: all
+// ANCHOR: includes
 use ggez;
 use ggez::graphics;
 use ggez::graphics::DrawParam;
@@ -9,6 +11,7 @@ use specs::{
 };
 
 use std::path;
+// ANCHOR_END: includes
 
 const TILE_WIDTH: f32 = 32.0;
 
@@ -175,6 +178,7 @@ pub fn create_player(world: &mut World, position: Position) {
         .build();
 }
 
+// ANCHOR: init_level
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
     const MAP: &str = "
@@ -191,7 +195,9 @@ pub fn initialize_level(world: &mut World) {
 
     load_map(world, MAP.to_string());
 }
+// ANCHOR_END: init_level
 
+// ANCHOR: load_map
 pub fn load_map(world: &mut World, map_string: String) {
     // read all lines
     let rows: Vec<&str> = map_string.trim().split('\n').map(|x| x.trim()).collect();
@@ -232,6 +238,8 @@ pub fn load_map(world: &mut World, map_string: String) {
         }
     }
 }
+// ANCHOR_END: load_map
+
 pub fn main() -> GameResult {
     let mut world = World::new();
     register_components(&mut world);
@@ -250,3 +258,5 @@ pub fn main() -> GameResult {
     // Run the main event loop
     event::run(context, event_loop, game)
 }
+
+// ANCHOR_END: all

--- a/code/rust-sokoban-c02-02/src/main.rs
+++ b/code/rust-sokoban-c02-02/src/main.rs
@@ -1,3 +1,5 @@
+// ANCHOR: all
+// ANCHOR: includes
 use ggez;
 use ggez::event::{KeyCode, KeyMods};
 use ggez::graphics;
@@ -11,6 +13,7 @@ use specs::{
 };
 
 use std::path;
+// ANCHOR_END: includes
 
 const TILE_WIDTH: f32 = 32.0;
 
@@ -45,11 +48,13 @@ pub struct Box {}
 #[storage(VecStorage)]
 pub struct BoxSpot {}
 
+// ANCHOR: input_queue
 // Resources
 #[derive(Default)]
 pub struct InputQueue {
     pub keys_pressed: Vec<KeyCode>,
 }
+// ANCHOR_END: input_queue
 
 // Systems
 pub struct RenderingSystem<'a> {
@@ -91,6 +96,7 @@ impl<'a> System<'a> for RenderingSystem<'a> {
     }
 }
 
+// ANCHOR: input_system
 pub struct InputSystem {}
 
 impl<'a> System<'a> for InputSystem {
@@ -119,6 +125,7 @@ impl<'a> System<'a> for InputSystem {
         }
     }
 }
+// ANCHOR_END: input_system
 
 // This struct will hold all our game state
 // For now there is nothing to be held, but we'll add
@@ -131,7 +138,10 @@ struct Game {
 // two things:
 // - updating
 // - rendering
+// ANCHOR: event_handler_1
 impl event::EventHandler for Game {
+    // ANCHOR_END: event_handler_1
+    // ANCHOR: update
     fn update(&mut self, _context: &mut Context) -> GameResult {
         // Run input system
         {
@@ -141,6 +151,7 @@ impl event::EventHandler for Game {
 
         Ok(())
     }
+    // ANCHOR_END: update
 
     fn draw(&mut self, context: &mut Context) -> GameResult {
         // Render game entities
@@ -152,6 +163,8 @@ impl event::EventHandler for Game {
         Ok(())
     }
 
+    // ANCHOR: key_down_event
+    // ANCHOR: event_handler_2
     fn key_down_event(
         &mut self,
         _context: &mut Context,
@@ -160,11 +173,17 @@ impl event::EventHandler for Game {
         _repeat: bool,
     ) {
         println!("Key pressed: {:?}", keycode);
+        // ANCHOR_END: event_handler_2
 
         let mut input_queue = self.world.write_resource::<InputQueue>();
         input_queue.keys_pressed.push(keycode);
+        // ANCHOR: event_handler_3
     }
+    // ANCHOR_END: event_handler_3
+    // ANCHOR_END: key_down_event
+    // ANCHOR: event_handler_4
 }
+// ANCHOR_END: event_handler_4
 
 // Register components with the world
 pub fn register_components(world: &mut World) {
@@ -176,9 +195,11 @@ pub fn register_components(world: &mut World) {
     world.register::<BoxSpot>();
 }
 
+// ANCHOR: register_resources
 pub fn register_resources(world: &mut World) {
     world.insert(InputQueue::default())
 }
+// ANCHOR_END: register_resources
 
 // Create a wall entity
 pub fn create_wall(world: &mut World, position: Position) {
@@ -292,6 +313,7 @@ pub fn load_map(world: &mut World, map_string: String) {
         }
     }
 }
+// ANCHOR: main
 pub fn main() -> GameResult {
     let mut world = World::new();
     register_components(&mut world);
@@ -311,3 +333,5 @@ pub fn main() -> GameResult {
     // Run the main event loop
     event::run(context, event_loop, game)
 }
+// ANCHOR_END: main
+// ANCHOR_END: all

--- a/code/rust-sokoban-c02-03/src/main.rs
+++ b/code/rust-sokoban-c02-03/src/main.rs
@@ -1,3 +1,4 @@
+// ANCHOR: all
 use ggez;
 use ggez::event::KeyCode;
 use ggez::event::KeyMods;
@@ -52,6 +53,7 @@ pub struct Box {}
 #[storage(VecStorage)]
 pub struct BoxSpot {}
 
+// ANCHOR: new_components
 #[derive(Component, Default)]
 #[storage(NullStorage)]
 pub struct Movable;
@@ -59,6 +61,7 @@ pub struct Movable;
 #[derive(Component, Default)]
 #[storage(NullStorage)]
 pub struct Immovable;
+// ANCHOR_END: new_components
 
 // Resources
 #[derive(Default)]
@@ -108,6 +111,7 @@ impl<'a> System<'a> for RenderingSystem<'a> {
 
 pub struct InputSystem {}
 
+// ANCHOR: input_system
 // System implementation
 impl<'a> System<'a> for InputSystem {
     // Data
@@ -195,6 +199,7 @@ impl<'a> System<'a> for InputSystem {
         }
     }
 }
+// ANCHOR_END: input_system
 
 // This struct will hold all our game state
 // For now there is nothing to be held, but we'll add
@@ -242,22 +247,27 @@ impl event::EventHandler for Game {
     }
 }
 
+// ANCHOR: register_components_1
 // Register components with the world
 pub fn register_components(world: &mut World) {
+    // ANCHOR_END: register_components_1
     world.register::<Position>();
     world.register::<Renderable>();
     world.register::<Player>();
     world.register::<Wall>();
     world.register::<Box>();
     world.register::<BoxSpot>();
+    // ANCHOR: register_components_2
     world.register::<Movable>();
     world.register::<Immovable>();
 }
+// ANCHOR_END: register_components_2
 
 pub fn register_resources(world: &mut World) {
     world.insert(InputQueue::default())
 }
 
+// ANCHOR: with_movable_or_immovable
 // Create a wall entity
 pub fn create_wall(world: &mut World, position: Position) {
     world
@@ -315,6 +325,7 @@ pub fn create_player(world: &mut World, position: Position) {
         .with(Movable)
         .build();
 }
+// ANCHOR_END: with_movable_or_immovable
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
@@ -392,3 +403,4 @@ pub fn main() -> GameResult {
     // Run the main event loop
     event::run(context, event_loop, game)
 }
+// ANCHOR_END: all

--- a/code/rust-sokoban-c02-05/src/main.rs
+++ b/code/rust-sokoban-c02-05/src/main.rs
@@ -21,6 +21,7 @@ struct Game {
     world: World,
 }
 
+// ANCHOR: event_handler_1
 impl event::EventHandler for Game {
     fn update(&mut self, _context: &mut Context) -> GameResult {
         // Run input system
@@ -37,6 +38,7 @@ impl event::EventHandler for Game {
 
         Ok(())
     }
+    // ANCHOR_END: event_handler_1
 
     fn draw(&mut self, context: &mut Context) -> GameResult {
         // Render game entities
@@ -60,7 +62,9 @@ impl event::EventHandler for Game {
         let mut input_queue = self.world.write_resource::<InputQueue>();
         input_queue.keys_pressed.push(keycode);
     }
+    // ANCHOR: event_handler_2
 }
+// ANCHOR_END: event_handler_2
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {

--- a/code/rust-sokoban-c02-05/src/resources.rs
+++ b/code/rust-sokoban-c02-05/src/resources.rs
@@ -9,16 +9,21 @@ pub struct InputQueue {
     pub keys_pressed: Vec<KeyCode>,
 }
 
+// ANCHOR: register_resources
 pub fn register_resources(world: &mut World) {
     world.insert(InputQueue::default());
     world.insert(Gameplay::default());
 }
+// ANCHOR_END: register_resources
 
+// ANCHOR: gameplay_state
 pub enum GameplayState {
     Playing,
     Won
 }
+// ANCHOR_END: gameplay_state
 
+// ANCHOR: gameplay_state_display
 impl Display for GameplayState {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str(match self {
@@ -28,15 +33,20 @@ impl Display for GameplayState {
         Ok(())
     }
 }
+// ANCHOR_END: gameplay_state_display
 
+// ANCHOR: gameplay_state_default
 impl Default for GameplayState {
     fn default() -> Self {
         Self::Playing
     }
 }
+// ANCHOR_END: gameplay_state_default
 
+// ANCHOR: gameplay
 #[derive(Default)]
 pub struct Gameplay {
     pub state: GameplayState,
     pub moves_count: u32
 }
+// ANCHOR_END: gameplay

--- a/code/rust-sokoban-c02-05/src/systems/input_system.rs
+++ b/code/rust-sokoban-c02-05/src/systems/input_system.rs
@@ -1,3 +1,4 @@
+// ANCHOR: includes
 use crate::components::*;
 use crate::constants::*;
 use crate::resources::{InputQueue, Gameplay};
@@ -5,7 +6,9 @@ use ggez::event::KeyCode;
 use specs::world::Index;
 use specs::{Entities, Join, ReadStorage, System, Write, WriteStorage};
 use std::collections::HashMap;
+// ANCHOR_END: includes
 
+// ANCHOR: input_system_1
 pub struct InputSystem {}
 
 // System implementation
@@ -23,6 +26,7 @@ impl<'a> System<'a> for InputSystem {
 
     fn run(&mut self, data: Self::SystemData) {
         let (mut input_queue, mut gameplay, entities, mut positions, players, movables, immovables) = data;
+        // ANCHOR_END: input_system_1
 
         let mut to_move = Vec::new();
 
@@ -81,6 +85,7 @@ impl<'a> System<'a> for InputSystem {
             }
         }
 
+        // ANCHOR: input_system_2
         // We've just moved, so let's increase the number of moves
         if to_move.len() > 0 {
             gameplay.moves_count += 1;
@@ -101,3 +106,5 @@ impl<'a> System<'a> for InputSystem {
         }
     }
 }
+
+// ANCHOR_END: input_system_2

--- a/code/rust-sokoban-c02-05/src/systems/rendering_system.rs
+++ b/code/rust-sokoban-c02-05/src/systems/rendering_system.rs
@@ -13,6 +13,7 @@ pub struct RenderingSystem<'a> {
     pub context: &'a mut Context,
 }
 
+// ANCHOR: draw_text
 impl RenderingSystem<'_> {
     pub fn draw_text(&mut self, text_string: &str, x: f32, y: f32) {
         let text = graphics::Text::new(text_string);
@@ -30,7 +31,9 @@ impl RenderingSystem<'_> {
         .expect("expected drawing queued text");
     }
 }
+// ANCHOR_END: draw_text
 
+// ANCHOR: rendering_system_1
 // System implementation
 impl<'a> System<'a> for RenderingSystem<'a> {
     // Data
@@ -38,6 +41,7 @@ impl<'a> System<'a> for RenderingSystem<'a> {
 
     fn run(&mut self, data: Self::SystemData) {
         let (gameplay, positions, renderables) = data;
+        // ANCHOR_END: rendering_system_1
 
         // Clearing the screen (this gives us the backround colour)
         graphics::clear(self.context, graphics::Color::new(0.95, 0.95, 0.95, 1.0));
@@ -60,6 +64,7 @@ impl<'a> System<'a> for RenderingSystem<'a> {
             graphics::draw(self.context, &image, draw_params).expect("expected render");
         }
 
+        // ANCHOR: rendering_system_2
         // Render any text
         self.draw_text(&gameplay.state.to_string(), 525.0, 80.0);
         self.draw_text(&gameplay.moves_count.to_string(), 525.0, 100.0);
@@ -69,3 +74,4 @@ impl<'a> System<'a> for RenderingSystem<'a> {
         graphics::present(self.context).expect("expected to present");
     }
 }
+// ANCHOR_END: rendering_system_2

--- a/code/rust-sokoban-c03-01/src/components.rs
+++ b/code/rust-sokoban-c03-01/src/components.rs
@@ -25,12 +25,17 @@ pub struct Wall {}
 #[storage(VecStorage)]
 pub struct Player {}
 
+// ANCHOR: box_colour_partialeq
 #[derive(PartialEq)]
+// ANCHOR: box_colour
 pub enum BoxColour {
     Red,
     Blue,
 }
+// ANCHOR_END: box_colour
+// ANCHOR_END: box_colour_partialeq
 
+// ANCHOR: box_colour_display
 impl Display for BoxColour {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str(match self {
@@ -40,7 +45,9 @@ impl Display for BoxColour {
         Ok(())
     }
 }
+// ANCHOR_END: box_colour_display
 
+// ANCHOR: box_and_box_spot_changes
 #[derive(Component)]
 #[storage(VecStorage)]
 pub struct Box {
@@ -52,6 +59,7 @@ pub struct Box {
 pub struct BoxSpot {
     pub colour: BoxColour,
 }
+// ANCHOR_END: box_and_box_spot_changes
 
 #[derive(Component, Default)]
 #[storage(NullStorage)]

--- a/code/rust-sokoban-c03-01/src/entities.rs
+++ b/code/rust-sokoban-c03-01/src/entities.rs
@@ -24,6 +24,7 @@ pub fn create_floor(world: &mut World, position: Position) {
         .build();
 }
 
+// ANCHOR: with_box_colour
 pub fn create_box(world: &mut World, position: Position, colour: BoxColour) {
     world
         .create_entity()
@@ -46,6 +47,7 @@ pub fn create_box_spot(world: &mut World, position: Position, colour: BoxColour)
         .with(BoxSpot { colour })
         .build();
 }
+// ANCHOR_END: with_box_colour
 
 pub fn create_player(world: &mut World, position: Position) {
     world

--- a/code/rust-sokoban-c03-01/src/main.rs
+++ b/code/rust-sokoban-c03-01/src/main.rs
@@ -62,6 +62,7 @@ impl event::EventHandler for Game {
     }
 }
 
+// ANCHOR: static_map
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
     const MAP: &str = "
@@ -78,6 +79,7 @@ pub fn initialize_level(world: &mut World) {
 
     load_map(world, MAP.to_string());
 }
+// ANCHOR_END: static_map
 
 pub fn main() -> GameResult {
     let mut world = World::new();

--- a/code/rust-sokoban-c03-01/src/systems/gameplay_state_system.rs
+++ b/code/rust-sokoban-c03-01/src/systems/gameplay_state_system.rs
@@ -17,6 +17,7 @@ impl<'a> System<'a> for GameplayStateSystem {
         ReadStorage<'a, BoxSpot>,
     );
 
+    // ANCHOR: run
     fn run(&mut self, data: Self::SystemData) {
         let (mut gameplay_state, positions, boxes, box_spots) = data;
 
@@ -48,4 +49,5 @@ impl<'a> System<'a> for GameplayStateSystem {
         // game has been won
         gameplay_state.state = GameplayState::Won;
     }
+    // ANCHOR_END: run
 }

--- a/code/rust-sokoban-c03-02/src/components.rs
+++ b/code/rust-sokoban-c03-02/src/components.rs
@@ -11,18 +11,25 @@ pub struct Position {
     pub z: u8,
 }
 
+// ANCHOR: renderable_kind
 pub enum RenderableKind {
     Static,
     Animated,
 }
+// ANCHOR_END: renderable_kind
 
+// ANCHOR: renderable_struct
 #[derive(Component)]
 #[storage(VecStorage)]
 pub struct Renderable {
     paths: Vec<String>,
 }
+// ANCHOR_END: renderable_struct
 
+// ANCHOR: renderable_impl
 impl Renderable {
+    //ANCHOR_END: renderable_impl
+    // ANCHOR: renderable_new
     pub fn new_static(path: String) -> Self {
         Self { paths: vec![path] }
     }
@@ -30,7 +37,9 @@ impl Renderable {
     pub fn new_animated(paths: Vec<String>) -> Self {
         Self { paths }
     }
+    // ANCHOR_END: renderable_new
 
+    // ANCHOR: renderable_kind_impl
     pub fn kind(&self) -> RenderableKind {
         match self.paths.len() {
             0 => panic!("invalid renderable"),
@@ -38,14 +47,19 @@ impl Renderable {
             _ => RenderableKind::Animated,
         }
     }
+    // ANCHOR_END: renderable_kind_impl
 
+    // ANCHOR: renderable_path
     pub fn path(&self, path_index: usize) -> String {
         // If we get asked for a path that is larger than the
         // number of paths we actually have, we simply mod the index
         // with the length to get an index that is in range.
         self.paths[path_index % self.paths.len()].clone()
     }
+    // ANCHOR_END: renderable_path
+    // ANCHOR: renderable_end
 }
+// ANCHOR_END: renderable_end
 
 #[derive(Component)]
 #[storage(VecStorage)]

--- a/code/rust-sokoban-c03-02/src/entities.rs
+++ b/code/rust-sokoban-c03-02/src/entities.rs
@@ -2,6 +2,7 @@ use crate::components::*;
 use specs::{Builder, World, WorldExt};
 
 // Create a wall entity
+// ANCHOR: create_wall
 pub fn create_wall(world: &mut World, position: Position) {
     world
         .create_entity()
@@ -11,6 +12,7 @@ pub fn create_wall(world: &mut World, position: Position) {
         .with(Immovable)
         .build();
 }
+// ANCHOR_END: create_wall
 
 pub fn create_floor(world: &mut World, position: Position) {
     world
@@ -45,6 +47,7 @@ pub fn create_box_spot(world: &mut World, position: Position, colour: BoxColour)
         .build();
 }
 
+// ANCHOR: create_player
 pub fn create_player(world: &mut World, position: Position) {
     world
         .create_entity()
@@ -58,3 +61,4 @@ pub fn create_player(world: &mut World, position: Position) {
         .with(Movable)
         .build();
 }
+// ANCHOR_END: create_player

--- a/code/rust-sokoban-c03-02/src/main.rs
+++ b/code/rust-sokoban-c03-02/src/main.rs
@@ -21,7 +21,10 @@ struct Game {
     world: World,
 }
 
+// ANCHOR: event_handler_impl
 impl event::EventHandler for Game {
+    // ANCHOR_END: event_handler_impl
+    // ANCHOR: update
     fn update(&mut self, context: &mut Context) -> GameResult {
         // Run input system
         {
@@ -43,6 +46,7 @@ impl event::EventHandler for Game {
 
         Ok(())
     }
+    // ANCHOR_END: update
 
     fn draw(&mut self, context: &mut Context) -> GameResult {
         // Render game entities
@@ -66,7 +70,9 @@ impl event::EventHandler for Game {
         let mut input_queue = self.world.write_resource::<InputQueue>();
         input_queue.keys_pressed.push(keycode);
     }
+    // ANCHOR: event_handler_end
 }
+// ANCHOR_END: event_handler_end
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {

--- a/code/rust-sokoban-c03-02/src/resources.rs
+++ b/code/rust-sokoban-c03-02/src/resources.rs
@@ -9,11 +9,13 @@ pub struct InputQueue {
     pub keys_pressed: Vec<KeyCode>,
 }
 
+// ANCHOR: register_resources
 pub fn register_resources(world: &mut World) {
     world.insert(InputQueue::default());
     world.insert(Gameplay::default());
     world.insert(Time::default());
 }
+// ANCHOR_END: register_resources
 
 pub enum GameplayState {
     Playing,
@@ -42,7 +44,9 @@ pub struct Gameplay {
     pub moves_count: u32,
 }
 
+// ANCHOR: time_struct
 #[derive(Default)]
 pub struct Time {
     pub delta: Duration,
 }
+// ANCHOR_END: time_struct

--- a/code/rust-sokoban-c03-02/src/systems/rendering_system.rs
+++ b/code/rust-sokoban-c03-02/src/systems/rendering_system.rs
@@ -14,7 +14,9 @@ pub struct RenderingSystem<'a> {
     pub context: &'a mut Context,
 }
 
+// ANCHOR: rendering_system_impl
 impl RenderingSystem<'_> {
+    // ANCHOR_END: rendering_system_impl
     pub fn draw_text(&mut self, text_string: &str, x: f32, y: f32) {
         let text = graphics::Text::new(text_string);
         let destination = na::Point2::new(x, y);
@@ -31,6 +33,7 @@ impl RenderingSystem<'_> {
         .expect("expected drawing queued text");
     }
 
+    // ANCHOR: get_image
     pub fn get_image(&mut self, renderable: &Renderable, delta: Duration) -> Image {
         let path_index = match renderable.kind() {
             RenderableKind::Static => {
@@ -51,9 +54,13 @@ impl RenderingSystem<'_> {
 
         Image::new(self.context, image_path).expect("expected image")
     }
+    // ANCHOR_END: get_image
+    // ANCHOR: rendering_system_end
 }
+// ANCHOR_END: rendering_system_end
 
 // System implementation
+// ANCHOR: system_impl
 impl<'a> System<'a> for RenderingSystem<'a> {
     // Data
     type SystemData = (
@@ -62,9 +69,12 @@ impl<'a> System<'a> for RenderingSystem<'a> {
         ReadStorage<'a, Position>,
         ReadStorage<'a, Renderable>,
     );
+    // ANCHOR_END: system_impl
 
+    // ANCHOR: run_1
     fn run(&mut self, data: Self::SystemData) {
         let (gameplay, time, positions, renderables) = data;
+        // ANCHOR_END: run_1
 
         // Clearing the screen (this gives us the backround colour)
         graphics::clear(self.context, graphics::Color::new(0.95, 0.95, 0.95, 1.0));
@@ -76,16 +86,20 @@ impl<'a> System<'a> for RenderingSystem<'a> {
 
         // Iterate through all pairs of positions & renderables, load the image
         // and draw it at the specified position.
+        // ANCHOR: run_for
         for (position, renderable) in rendering_data.iter() {
             // Load the image
             let image = self.get_image(renderable, time.delta);
+            // ANCHOR_END: run_for
             let x = position.x as f32 * TILE_WIDTH;
             let y = position.y as f32 * TILE_WIDTH;
 
             // draw
             let draw_params = DrawParam::new().dest(na::Point2::new(x, y));
             graphics::draw(self.context, &image, draw_params).expect("expected render");
+            // ANCHOR: run_for_end
         }
+        // ANCHOR_END: run_for_end
 
         // Render any text
         self.draw_text(&gameplay.state.to_string(), 525.0, 80.0);
@@ -94,5 +108,9 @@ impl<'a> System<'a> for RenderingSystem<'a> {
         // Finally, present the context, this will actually display everything
         // on the screen.
         graphics::present(self.context).expect("expected to present");
+        // ANCHOR: run_end
     }
+    // ANCHOR_END: run_end
+    // ANCHOR: system_impl_end
 }
+// ANCHOR_END: system_impl_end

--- a/code/rust-sokoban-c03-03/src/audio.rs
+++ b/code/rust-sokoban-c03-03/src/audio.rs
@@ -3,11 +3,14 @@ use ggez::{audio, Context};
 use specs::{World, WorldExt};
 use std::collections::HashMap;
 
+// ANCHOR: audio_store_struct
 #[derive(Default)]
 pub struct AudioStore {
     pub sounds: HashMap<String, audio::Source>,
 }
+// ANCHOR_END: audio_store_struct
 
+// ANCHOR: audio_store_impl
 impl AudioStore {
     pub fn play_sound(&mut self, sound: &String) {
         let _ = self
@@ -17,7 +20,9 @@ impl AudioStore {
             .play_detached();
     }
 }
+// ANCHOR_END: audio_store_impl
 
+// ANCHOR: initialize_sounds
 pub fn initialize_sounds(world: &mut World, context: &mut Context) {
     let mut audio_store = world.write_resource::<AudioStore>();
     let sounds = ["correct", "incorrect", "wall"];
@@ -30,3 +35,4 @@ pub fn initialize_sounds(world: &mut World, context: &mut Context) {
         audio_store.sounds.insert(sound_name, sound_source);
     }
 }
+// ANCHOR_END: initialize_sounds

--- a/code/rust-sokoban-c03-03/src/events.rs
+++ b/code/rust-sokoban-c03-03/src/events.rs
@@ -1,3 +1,4 @@
+// ANCHOR: structs
 pub type EntityId = u32;
 
 #[derive(Debug)]
@@ -9,7 +10,9 @@ pub struct EntityMoved {
 pub struct BoxPlacedOnSpot {
     pub is_correct_spot: bool,
 }
+// ANCHOR_END: structs
 
+// ANCHOR: event_enum
 #[derive(Debug)]
 pub enum Event {
     // Fired when the player hits an obstacle like a wall
@@ -21,3 +24,4 @@ pub enum Event {
     // Fired when the box is placed on a spot
     BoxPlacedOnSpot(BoxPlacedOnSpot),
 }
+// ANCHOR_END: event_enum

--- a/code/rust-sokoban-c03-03/src/main.rs
+++ b/code/rust-sokoban-c03-03/src/main.rs
@@ -5,6 +5,7 @@ use ggez::{conf, event, timer, Context, GameResult};
 use specs::{RunNow, World, WorldExt};
 use std::path;
 
+// ANCHOR: mods
 mod audio;
 mod components;
 mod constants;
@@ -19,13 +20,16 @@ use crate::components::*;
 use crate::map::*;
 use crate::resources::*;
 use crate::systems::*;
+// ANCHOR_END: mods
 
 struct Game {
     world: World,
 }
 
+// ANCHOR: event_handler_start
 impl event::EventHandler for Game {
     fn update(&mut self, context: &mut Context) -> GameResult {
+        // ANCHOR_END: event_handler_start
         // Run input system
         {
             let mut is = InputSystem {};
@@ -44,6 +48,7 @@ impl event::EventHandler for Game {
             time.delta += timer::delta(context);
         }
 
+        // ANCHOR: event_sys
         // Run event system
         {
             let mut es = EventSystem {};
@@ -52,6 +57,7 @@ impl event::EventHandler for Game {
 
         Ok(())
     }
+    // ANCHOR_END: event_sys
 
     fn draw(&mut self, context: &mut Context) -> GameResult {
         // Render game entities
@@ -75,7 +81,9 @@ impl event::EventHandler for Game {
         let mut input_queue = self.world.write_resource::<InputQueue>();
         input_queue.keys_pressed.push(keycode);
     }
+    // ANCHOR: event_handler_end
 }
+// ANCHOR_END: event_handler_end
 
 // Initialize the level
 pub fn initialize_level(world: &mut World) {
@@ -94,7 +102,9 @@ pub fn initialize_level(world: &mut World) {
     load_map(world, MAP.to_string());
 }
 
+// ANCHOR: main_start
 pub fn main() -> GameResult {
+    // ANCHOR_END: main_start
     let mut world = World::new();
     register_components(&mut world);
     register_resources(&mut world);
@@ -106,11 +116,15 @@ pub fn main() -> GameResult {
         .window_mode(conf::WindowMode::default().dimensions(800.0, 600.0))
         .add_resource_path(path::PathBuf::from("./resources"));
 
+    // ANCHOR: init_sounds
     let (context, event_loop) = &mut context_builder.build()?;
     initialize_sounds(&mut world, context);
+    // ANCHOR_END: init_sounds
 
     // Create the game state
     let game = &mut Game { world };
     // Run the main event loop
     event::run(context, event_loop, game)
+    // ANCHOR: main_end
 }
+// ANCHOR_END: main_end

--- a/code/rust-sokoban-c03-03/src/resources.rs
+++ b/code/rust-sokoban-c03-03/src/resources.rs
@@ -11,13 +11,19 @@ pub struct InputQueue {
     pub keys_pressed: Vec<KeyCode>,
 }
 
+// ANCHOR: register_resources_1
 pub fn register_resources(world: &mut World) {
     world.insert(InputQueue::default());
     world.insert(Gameplay::default());
     world.insert(Time::default());
     world.insert(EventQueue::default());
+    // ANCHOR_END: register_resources_1
+    // ANCHOR: register_resources_2
     world.insert(AudioStore::default());
+    // ANCHOR_END: register_resources_2
+    // ANCHOR: register_resources_end
 }
+// ANCHOR_END: register_resources_end
 
 pub enum GameplayState {
     Playing,
@@ -51,7 +57,9 @@ pub struct Time {
     pub delta: Duration,
 }
 
+// ANCHOR: event_queue
 #[derive(Default)]
 pub struct EventQueue {
     pub events: Vec<Event>,
 }
+// ANCHOR_END: event_queue

--- a/code/rust-sokoban-c03-03/src/systems/event_system.rs
+++ b/code/rust-sokoban-c03-03/src/systems/event_system.rs
@@ -1,40 +1,64 @@
+// ANCHOR: include_start
 use crate::{
+    // ANCHOR_END: include_start
+    // ANCHOR: include_audio_store
     audio::AudioStore,
+    // ANCHOR_END: include_audio_store
+    // ANCHOR: include_end
     components::*,
     events::{BoxPlacedOnSpot, EntityMoved, Event},
     resources::EventQueue,
 };
 use specs::{Entities, Join, ReadStorage, System, Write};
 use std::collections::HashMap;
+// ANCHOR_END: include_end
 
 pub struct EventSystem {}
 
 // System implementation
+// ANCHOR: event_sys_impl_start
 impl<'a> System<'a> for EventSystem {
+    // ANCHOR_END: event_sys_impl_start
+    // ANCHOR: sys_data_1
     // Data
     type SystemData = (
         Write<'a, EventQueue>,
+    // ANCHOR_END: sys_data_1
+    // ANCHOR: sys_data_audio
         Write<'a, AudioStore>,
+    // ANCHOR_END: sys_data_audio
+    // ANCHOR: sys_data_2
         Entities<'a>,
         ReadStorage<'a, Box>,
         ReadStorage<'a, BoxSpot>,
         ReadStorage<'a, Position>,
     );
+    // ANCHOR_END: sys_data_2
 
+    // ANCHOR: run_start
+    // ANCHOR: run_full
     fn run(&mut self, data: Self::SystemData) {
+        // ANCHOR_END: run_start
+        // ANCHOR: run_let_data
         let (mut event_queue, mut audio_store, entities, boxes, box_spots, positions) = data;
+        // ANCHOR_END: run_let_data
 
+        // ANCHOR: run_body_1
         let mut new_events = Vec::new();
 
         for event in event_queue.events.drain(..) {
             println!("New event: {:?}", event);
 
+            // ANCHOR: play_sound_1
             match event {
                 Event::PlayerHitObstacle => {
                     // play sound here
+                    // ANCHOR_END: run_body_1
                     audio_store.play_sound(&"wall".to_string());
+                    // ANCHOR: run_body_2
                 }
                 Event::EntityMoved(EntityMoved { id }) => {
+                    // ANCHOR_END: play_sound_1
                     // An entity was just moved, check if it was a box and fire
                     // more events if it's been moved on a spot.
                     if let Some(the_box) = boxes.get(entities.entity(id)) {
@@ -56,6 +80,7 @@ impl<'a> System<'a> for EventSystem {
                             }
                         }
                     }
+                    // ANCHOR: play_sound_2
                 }
                 Event::BoxPlacedOnSpot(BoxPlacedOnSpot { is_correct_spot }) => {
                     // play sound here
@@ -66,10 +91,16 @@ impl<'a> System<'a> for EventSystem {
                     };
 
                     audio_store.play_sound(&sound.to_string())
+                    // ANCHOR: run_body_3
                 }
             }
+            // ANCHOR_END: play_sound_2
         }
 
         event_queue.events.append(&mut new_events);
+        // ANCHOR: run_end
     }
 }
+// ANCHOR_END: run_end
+// ANCHOR_END: run_body_3
+// ANCHOR_END: run_full

--- a/code/rust-sokoban-c03-03/src/systems/input_system.rs
+++ b/code/rust-sokoban-c03-03/src/systems/input_system.rs
@@ -1,3 +1,4 @@
+// ANCHOR: includes
 use crate::components::*;
 use crate::constants::*;
 use crate::events::{EntityMoved, Event};
@@ -6,12 +7,16 @@ use ggez::event::KeyCode;
 use specs::world::Index;
 use specs::{Entities, Join, ReadStorage, System, Write, WriteStorage};
 use std::collections::HashMap;
+// ANCHOR_END: includes
 
 pub struct InputSystem {}
 
 // System implementation
+// ANCHOR: input_system_start
 impl<'a> System<'a> for InputSystem {
+    // ANCHOR_END: input_system_start
     // Data
+    // ANCHOR: input_system_data
     type SystemData = (
         Write<'a, EventQueue>,
         Write<'a, InputQueue>,
@@ -22,8 +27,12 @@ impl<'a> System<'a> for InputSystem {
         ReadStorage<'a, Movable>,
         ReadStorage<'a, Immovable>,
     );
+    // ANCHOR_END: input_system_data
 
+    // ANCHOR: run_start
     fn run(&mut self, data: Self::SystemData) {
+        // ANCHOR_END: run_start
+        // ANCHOR: run_let_data
         let (
             mut events,
             mut input_queue,
@@ -34,6 +43,7 @@ impl<'a> System<'a> for InputSystem {
             movables,
             immovables,
         ) = data;
+        // ANCHOR_END: run_let_data
 
         let mut to_move = Vec::new();
 
@@ -76,12 +86,14 @@ impl<'a> System<'a> for InputSystem {
                     // find a movable
                     // if it exists, we try to move it and continue
                     // if it doesn't exist, we continue and try to find an immovable instead
+                    // ANCHOR: input_system_for_for_match
                     match mov.get(&pos) {
                         Some(id) => to_move.push((key, id.clone())),
                         None => {
                             // find an immovable
                             // if it exists, we need to stop and not move anything
                             // if it doesn't exist, we stop because we found a gap
+                            // ANCHOR: immov_match
                             match immov.get(&pos) {
                                 Some(_id) => {
                                     to_move.clear();
@@ -89,6 +101,7 @@ impl<'a> System<'a> for InputSystem {
                                 }
                                 None => break,
                             }
+                            // ANCHOR_END: immov_match
                         }
                     }
                 }
@@ -101,6 +114,7 @@ impl<'a> System<'a> for InputSystem {
         }
 
         // Now actually move what needs to be moved
+        // ANCHOR: input_system_for_act
         for (key, id) in to_move {
             let position = positions.get_mut(entities.entity(id));
             if let Some(position) = position {
@@ -116,5 +130,10 @@ impl<'a> System<'a> for InputSystem {
             // Fire an event for the entity that just moved
             events.events.push(Event::EntityMoved(EntityMoved { id }));
         }
+        // ANCHOR_END: input_system_for_act
+        // ANCHOR: run_end
     }
+    // ANCHOR_END: run_end
+    // ANCHOR: input_system_end
 }
+// ANCHOR_END: input_system_end

--- a/src/c01-01-setup.md
+++ b/src/c01-01-setup.md
@@ -68,7 +68,7 @@ more dependencies. If this step fails and you see errors related to `alsa` and `
 Now let's actually use ggez in the main file and set up our window. This is just the simplest example of a ggez program that will give us a window with nothing else. Copy and paste this into the `main.rs` file and run again.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-01/src/main.rs}}
+{{#include ../code/rust-sokoban-c01-01/src/main.rs:all}}
 ```
 
 You should see something like this.
@@ -84,12 +84,13 @@ Hopefully this should be a familiar concept from other languages you might know,
 
 ```rust
 // this will import conf, event, Context and GameResult from the ggez namespace
-{{#include ../code/rust-sokoban-c01-01/src/main.rs:1}}
+// and path from the std namespace
+{{#include ../code/rust-sokoban-c01-01/src/main.rs:includes}}
 ```
 
 ### Declaring a struct
 ```rust
-{{#include ../code/rust-sokoban-c01-01/src/main.rs:4:7}}
+{{#include ../code/rust-sokoban-c01-01/src/main.rs:struct}}
 ```
 
 > **_MORE:_**  Read more about structs [here](https://doc.rust-lang.org/book/ch05-00-structs.html).
@@ -99,7 +100,7 @@ Hopefully this should be a familiar concept from other languages you might know,
 A trait is much like an interface in other languages, it allows us to associate some behaviour with a particular type. In this case we want to implement the EventHandler trait and add that behaviour to our Game struct.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-01/src/main.rs:9:23}}
+{{#include ../code/rust-sokoban-c01-01/src/main.rs:trait}}
 ```
 
 > **_MORE:_**  Read more about traits [here](https://doc.rust-lang.org/book/ch10-02-traits.html).
@@ -109,7 +110,7 @@ A trait is much like an interface in other languages, it allows us to associate 
 We are also learning how to declare functions in Rust.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-01/src/main.rs:14:17}}
+{{#include ../code/rust-sokoban-c01-01/src/main.rs:functions}}
 ```
 
 You might be wondering what the self is, in this case self means that the update function is a member function, it belongs to an instance of the game struct and it cannot be called in a static context. 

--- a/src/c01-02-ecs.md
+++ b/src/c01-02-ecs.md
@@ -33,8 +33,8 @@ At first thinking in ECS might be difficult, so don't worry if you don't underst
 ## Specs
 Finally, let's bring in an ECS crate. There are a ton of them out there, but we will use [specs](https://specs.amethyst.rs/docs/tutorials/) for this book.
 
-```
-{{#include ../code/rust-sokoban-c01-03/Cargo.toml:9:11}}
+```toml
+{{#include ../code/rust-sokoban-c01-03/Cargo.toml:dependencies}}
 ```
 
 Next up, we'll start implementing entities and components!

--- a/src/c01-03-entities-components.md
+++ b/src/c01-03-entities-components.md
@@ -1,6 +1,14 @@
 # Components and entities
 In this section we will create our components, we'll see how to create entities and register everything to keep specs happy.
 
+## Includes
+
+We'll want to include the following types at the top of the file so we can create our components.
+
+```rust
+{{#include ../code/rust-sokoban-c01-03/src/main.rs:includes}}
+```
+
 ## Defining components
 Let's start by defining components. We previously discussed Position, Renderable and Movement - we'll skip movement for now. We will also need some components to identify each entity - for example we will need a Wall component so we can identify an entity as a wall by the fact that it has a wall component.
 
@@ -8,7 +16,7 @@ This should hopefully be straight-forward, the position components stores the x,
 
 
 ```rust
-{{#include ../code/rust-sokoban-c01-03/src/main.rs:13:42}}
+{{#include ../code/rust-sokoban-c01-03/src/main.rs:components}}
 ```
 
 Among the familiar Rust code we've got some new syntax, we're using a powerful Rust feature called `Procedural Macros` which is used in `#[storage(VecStorage)]`. These type of macros are essentially functions that at compile time consume some syntax and produce some new syntax.
@@ -19,7 +27,7 @@ Among the familiar Rust code we've got some new syntax, we're using a powerful R
 In order for specs to be happy we have to tell it ahead of time what components we will be using. Let's create a function to register components into specs.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-03/src/main.rs:61:69}}
+{{#include ../code/rust-sokoban-c01-03/src/main.rs:register_components}}
 ```
 
 ## Creating entities
@@ -28,7 +36,7 @@ An entity is simply a numeric identifier tied to a set of components. So the way
 This is how entity creation looks now.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-03/src/main.rs:71:124}}
+{{#include ../code/rust-sokoban-c01-03/src/main.rs:entities}}
 ```
 
 ## Assets
@@ -60,7 +68,7 @@ Let's add the images to our project. We'll add a `resources` folder which will h
 Finally, let's tie everything together. We'll need to create a specs::World object, we'll add that to our Game struct and we will initialize it first thing in our main. Here is the full code, running now should render the same blank window, but we've made tremendous progress in actually setting up our game components and entities! Next up, we'll get to rendering so we'll finally see something on screen!
 
 ```rust
-{{#include ../code/rust-sokoban-c01-03/src/main.rs}}
+{{#include ../code/rust-sokoban-c01-03/src/main.rs:all}}
 ```
 
 Note that running now will report some warnings in the console about unused import(s) and/or fields, don't worry about these just yet as we'll fix them in the coming chapters.

--- a/src/c01-04-rendering.md
+++ b/src/c01-04-rendering.md
@@ -2,11 +2,23 @@
 
 It's time for our first system, the rendering system. This system will be responsible for drawing all our entities on the screen.
 
+## Includes
+
+Add the following new imports:
+```rust
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:includes}}
+```
+
+Update the specs import with these new types:
+```rust
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:specs_includes}}
+```
+
 ## Rendering system setup
 First we'll define the `RenderingSystem` struct, it will need access to the ggez context in order to actually render.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-04/src/main.rs:47:49}}
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:render_struct}}
 ```
 
 We've got some new syntax here; `'a` is called a lifetime annotation. It's needed because the compiler can't see how long the reference in `RenderingSystem` is valid, meaning that we have to specify the lifetime annotation.
@@ -16,15 +28,15 @@ We've got some new syntax here; `'a` is called a lifetime annotation. It's neede
 Now let's implement the System trait for our Rendering system. This doesn't do anything yet, we're just setting up the scaffolding. The definition of SystemData means that we will have access to the storage of position and renderable components, and the fact that it's read storage means we only get immutable access, which is exactly what we need.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-04/src/main.rs:51:57}}
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:render_impl_1}}
         // implementation here
-{{#include ../code/rust-sokoban-c01-04/src/main.rs:83:84}}
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:render_impl_2}}
 ```
 
 Finally let's run the rendering system in our draw loop. This means that every time the game updates we will render the latest state of all our entities.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-04/src/main.rs:97:111}}
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:event_handler}}
 ```
 
 Running the game now should compile, but it will probably not do anything yet, since we haven't filled in any of the implementation of the rendering system and also we haven't created any entities.
@@ -38,7 +50,7 @@ Here is the implementation of the rendering system. It does a few things:
 * finally, present to the screen
 
 ```rust
-{{#include ../code/rust-sokoban-c01-04/src/main.rs:56:83}}
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:render_run}}
 ```
 
 ## Add some test entities
@@ -46,7 +58,7 @@ Here is the implementation of the rendering system. It does a few things:
 Let's create some test entities to make sure things are working correctly.
 
 ```rust
-{{#include ../code/rust-sokoban-c01-04/src/main.rs:179:204}}
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:init_level}}
 ```
 
 Finally, let's put everything together and run. You should see something like this! This is super exciting, now we have a proper rendering system and we can actually see something on the screen for the first time. Next up, we're going to work on the gameplay so it can actually feel like a game!
@@ -59,7 +71,7 @@ Final code below.
 
 
 ```rust
-{{#include ../code/rust-sokoban-c01-04/src/main.rs}}
+{{#include ../code/rust-sokoban-c01-04/src/main.rs:all}}
 ```
 
 > **_CODELINK:_**  You can see the full code in this example [here](https://github.com/iolivia/rust-sokoban/tree/master/code/rust-sokoban-c01-04).

--- a/src/c02-01-map-loading.md
+++ b/src/c02-01-map-loading.md
@@ -20,13 +20,13 @@ N is nothing: used for the outer edges of the map
 Let's make a string for this, eventually we can load from a file but for simplicity let's go with a constant in the code for now.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-01/src/main.rs:179:193}}
+{{#include ../code/rust-sokoban-c02-01/src/main.rs:init_level}}
 ```
 
 And here is the implementation of load map.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-01/src/main.rs:195:234}}
+{{#include ../code/rust-sokoban-c02-01/src/main.rs:load_map}}
 ```
 
 The most interesting Rust concept here is probably the `match`. We are using the basic feature of pattern matching here, we are simply matching on the values of each token found in the map config, but we could do a lot of more advanced conditions or types of patterns.
@@ -40,7 +40,7 @@ Now let's run the game and see what our map looks like.
 Final code below.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-01/src/main.rs}}
+{{#include ../code/rust-sokoban-c02-01/src/main.rs:all}}
 ```
 
 > **_CODELINK:_**  You can see the full code in this example [here](https://github.com/iolivia/rust-sokoban/tree/master/code/rust-sokoban-c02-01).

--- a/src/c02-02-move-player.md
+++ b/src/c02-02-move-player.md
@@ -8,22 +8,22 @@ The first step for making our player move is to start listening to input events.
 Let's start listening to key events. First we'll bring a few more modules into scope:
 
 ```rust
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:1:11}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:includes}}
 ```
 
 Then, we'll add this code inside the `event::EventHandler` implementation block for our Game:
 
 ```rust
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:134}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:event_handler_1}}
 
     // ...
 
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:155:162}}
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:166}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:event_handler_2}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:event_handler_3}}
 
     // ...
-
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:167}}
+    
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:event_handler_4}}
 ```
 
 If we run this we should see the print lines in the console.
@@ -43,31 +43,31 @@ If you are not familiar with the `{:?}` notation used when printing, this is jus
 Next up we'll add a resource, which is the specs way of sharing some state across systems which isn't part of your world. We'll use a resource for modelling the input queue of key presses, since that doesn't really fit into our existing components/entities model.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:48:52}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:input_queue}}
 ```
 
 And then we'll push the new key presses into the queue when `key_down_event` is called.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:134}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:event_handler_1}}
 
     // ...
 
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:155:166}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:key_down_event}}
 
     // ...
 
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:167}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:event_handler_4}}
 ```
 
 Finally, we need to register the resources into specs like we did for components.
 
 ```rust
 // Registering resources
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:179:181}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:register_resources}}
 
 // Registering resources in main
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:295:312}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:main}}
 ```
 
 ## Input system
@@ -75,13 +75,13 @@ Finally, we need to register the resources into specs like we did for components
 Using this code we have a resource that is a continuous queue of input key presses. Next up, we'll start processing these inputs in a system.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:94:121}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:input_system}}
 ```
 
 Finally we need to run the system in our update loop.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-02/src/main.rs:135:143}}
+{{#include ../code/rust-sokoban-c02-02/src/main.rs:update}}
 ```
 
 The input system is pretty simple, it grabs all the players and positions (we should only have one player but this code doesn't need to care about that, it could in theory work if we have multiple players that we want to control with the same input). And then for every player and position combination, it will grab the first key pressed and remove it from the input queue. It will then figure out what is the required transformation - for example if we press up we want to move one tile up and so on, and then applies this position update.

--- a/src/c02-03-push-box.md
+++ b/src/c02-03-push-box.md
@@ -12,9 +12,11 @@ Here are our two new components, nothing too new apart from two minor things:
 
 
 ```rust
-{{#include ../code/rust-sokoban-c02-03/src/main.rs:55:62}}
+{{#include ../code/rust-sokoban-c02-03/src/main.rs:new_components}}
 
-{{#include ../code/rust-sokoban-c02-03/src/main.rs:250:259}}
+{{#include ../code/rust-sokoban-c02-03/src/main.rs:register_components_1}}
+    // ...
+{{#include ../code/rust-sokoban-c02-03/src/main.rs:register_components_2}}
 ```
 
 Next, we'll add:
@@ -23,7 +25,7 @@ Next, we'll add:
 * do nothing with floors and box spots (as mentioned before they should not be part of our movement/collision system since they are inconsequential to the movement)
 
 ```rust
-{{#include ../code/rust-sokoban-c02-03/src/main.rs:266:321}}
+{{#include ../code/rust-sokoban-c02-03/src/main.rs:with_movable_or_immovable}}
 ```
 
 ## Movement requirements
@@ -55,7 +57,7 @@ So given this, let's start implementing this logic. Let's think about the logica
 Here is the new implementation of the input systems, it's a bit long but hopefully it makes sense.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-03/src/main.rs:113:197}}
+{{#include ../code/rust-sokoban-c02-03/src/main.rs:input_system}}
 ```
 
 Now if we run the code, we'll see it actually works! We can't go through walls anymore and we can push the box and it stops when it gets to the wall.
@@ -65,7 +67,7 @@ Now if we run the code, we'll see it actually works! We can't go through walls a
 Full code below.
 
 ```rust
-{{#include ../code/rust-sokoban-c02-03/src/main.rs}}
+{{#include ../code/rust-sokoban-c02-03/src/main.rs:all}}
 ```
 
 > **_CODELINK:_**  You can see the full code in this example [here](https://github.com/iolivia/rust-sokoban/tree/master/code/rust-sokoban-c02-03).

--- a/src/c02-04-modules.md
+++ b/src/c02-04-modules.md
@@ -46,21 +46,21 @@ Next up, let's move the constants into their own file. For now we are hardcoding
 
 ```rust
 // constants.rs
-{{#include ../code/rust-sokoban-c02-04/src/constants.rs}}
+{{#include ../code/rust-sokoban-c02-04/src/constants.rs:}}
 ```
 
 Next up, entity creation code is now into an entities file.
 
 ```rust
 // entities.rs
-{{#include ../code/rust-sokoban-c02-04/src/entities.rs}}
+{{#include ../code/rust-sokoban-c02-04/src/entities.rs:}}
 ```
 
 Now for the map loading.
 
 ```rust
 // map.rs
-{{#include ../code/rust-sokoban-c02-04/src/map.rs}}
+{{#include ../code/rust-sokoban-c02-04/src/map.rs:}}
 ```
 
 Finally, we'll move the systems code into their own files (RenderingSystem to rendering_system.rs and InputSystem to input_system.rs). It should just be a copy paste from main with some import removals, so go ahead and do that.
@@ -70,14 +70,14 @@ Now the interesting thing about systems is that it's a folder with multiple file
 
 ```rust
 // systems/mod.rs
-{{#include ../code/rust-sokoban-c02-04/src/systems/mod.rs}}
+{{#include ../code/rust-sokoban-c02-04/src/systems/mod.rs:}}
 ```
 
 Awesome, now that we've done that here is how our simplified main file looks like. Notice the mod and use declarations after the imports, those are again telling Rust that we want to use those modules.
 
 ```rust
 // main.rs
-{{#include ../code/rust-sokoban-c02-04/src/main.rs}}
+{{#include ../code/rust-sokoban-c02-04/src/main.rs:}}
 ```
 
 Feel free to run at this point, everything should work just the same, the only difference is now our code is much nicer and ready for more amazing Sokoban features.

--- a/src/c02-05-gameplay.md
+++ b/src/c02-05-gameplay.md
@@ -22,7 +22,7 @@ not associated with a specific entity. Let's start by defining a `Gameplay` reso
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c02-05/src/resources.rs:38:43}}
+{{#include ../code/rust-sokoban-c02-05/src/resources.rs:gameplay}}
 ```
 
 `Gameplay` has two fields: `state` and `moves_count`. These are used to track the
@@ -31,7 +31,7 @@ the number of moves made.  `state` is described by an `enum`, defined like so:
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c02-05/src/resources.rs:17:20}}
+{{#include ../code/rust-sokoban-c02-05/src/resources.rs:gameplay_state}}
 ```
 
 The eagle-eyed reader will note that we used a macro to derive the `Default` trait
@@ -43,14 +43,14 @@ automatically, we must implement `Default` for `Gameplay` ourselves.
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c02-05/src/resources.rs:32:36}}
+{{#include ../code/rust-sokoban-c02-05/src/resources.rs:gameplay_state_default}}
 ```
 
 Having defined the resource, let's register it with the world:
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c02-05/src/resources.rs:12:15}}
+{{#include ../code/rust-sokoban-c02-05/src/resources.rs:register_resources}}
 ```
 
 Now, when the game is started, the `Gameplay` resource will look like this:
@@ -73,8 +73,10 @@ definition.
 
 ```rust
 // input_system.rs
-{{#include ../code/rust-sokoban-c02-05/src/systems/input_system.rs:0:25}}
-        ...
+{{#include ../code/rust-sokoban-c02-05/src/systems/input_system.rs:includes}}
+
+{{#include ../code/rust-sokoban-c02-05/src/systems/input_system.rs:input_system_1}}
+        // ...
 ```
 
 Since we've already done the work to check if a player character will move in
@@ -83,8 +85,8 @@ counter.
 
 ```rust
 // input_system.rs
-        ...
-{{#include ../code/rust-sokoban-c02-05/src/systems/input_system.rs:83:105}}
+        // ...
+{{#include ../code/rust-sokoban-c02-05/src/systems/input_system.rs:input_system_2}}
 ```
 
 ## Gameplay System
@@ -111,13 +113,19 @@ Otherwise, the game is still in play.
 {{#include ../code/rust-sokoban-c02-05/src/systems/gameplay_state_system.rs::}}
 ```
 
-Finally, let's run the gameplay system in our main update loop.
+Then we'll need to add this to `systems/mod.rs` so it can be accessed from `main.rs`.
+```rust
+// systems/mod.rs
+{{#include ../code/rust-sokoban-c02-05/src/systems/mod.rs:}}
+```
+
+Finally, let's run the gameplay system in our main update loop. 
 
 ```rust
 // main.rs
-{{#include ../code/rust-sokoban-c02-05/src/main.rs:24:39}}
+{{#include ../code/rust-sokoban-c02-05/src/main.rs:event_handler_1}}
     // ...
-{{#include ../code/rust-sokoban-c02-05/src/main.rs:63}}
+{{#include ../code/rust-sokoban-c02-05/src/main.rs:event_handler_2}}
 ```
 
 
@@ -134,7 +142,7 @@ to render "Playing" or "Won".
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c02-05/src/resources.rs:21:30}}
+{{#include ../code/rust-sokoban-c02-05/src/resources.rs:gameplay_state_display}}
 ```
 
 Next, we'll add a `draw_text` method to `RenderingSystem`, so it can print
@@ -142,7 +150,7 @@ Next, we'll add a `draw_text` method to `RenderingSystem`, so it can print
 
 ```rust
 // rendering_systems.rs
-{{#include ../code/rust-sokoban-c02-05/src/systems/rendering_system.rs:16:32}}
+{{#include ../code/rust-sokoban-c02-05/src/systems/rendering_system.rs:draw_text}}
 ```
 
 ...and then we'll add the `Gameplay` resource to `RenderingSystem` so we can
@@ -151,7 +159,11 @@ resource.
 
 ```rust
 // rendering_system.rs
-{{#include ../code/rust-sokoban-c02-05/src/systems/rendering_system.rs:35:71}}
+{{#include ../code/rust-sokoban-c02-05/src/systems/rendering_system.rs:rendering_system_1}}
+
+        // ...
+
+{{#include ../code/rust-sokoban-c02-05/src/systems/rendering_system.rs:rendering_system_2}}
 ```
 
 At this point, the game will provide basic feedback to the user:

--- a/src/c03-01-colours.md
+++ b/src/c03-01-colours.md
@@ -42,14 +42,14 @@ Now let's add an enum for the colour (if you chose to implement more than two co
 
 ```rust
 // components.rs
-{{#include ../code/rust-sokoban-c03-01/src/components.rs:29:32}}
+{{#include ../code/rust-sokoban-c03-01/src/components.rs:box_colour}}
 ```
 
 Now let's use this enum both for the box and the spot. 
 
 ```rust
 // components.rs
-{{#include ../code/rust-sokoban-c03-01/src/components.rs:44:54}}
+{{#include ../code/rust-sokoban-c03-01/src/components.rs:box_and_box_spot_changes}}
 ```
 
 ## Entity creation
@@ -59,14 +59,14 @@ In order to create the correct string for the asset path we basically want `"/im
 
 ```rust
 // components.rs
-{{#include ../code/rust-sokoban-c03-01/src/components.rs:34:43}}
+{{#include ../code/rust-sokoban-c03-01/src/components.rs:box_colour_display}}
 ```
 
 Now let's include the colour in our entity creation code and use the fancy `colour.to_string()` we just made possible in the previous snippet.
 
 ```rust
 // entities.rs
-{{#include ../code/rust-sokoban-c03-01/src/entities.rs:27:48}}
+{{#include ../code/rust-sokoban-c03-01/src/entities.rs:with_box_colour}}
 ```
 
 ## Map
@@ -85,7 +85,7 @@ And let's update our static map in the main.
 
 ```rust
 // main.rs
-{{#include ../code/rust-sokoban-c03-01/src/main.rs:65:80}}
+{{#include ../code/rust-sokoban-c03-01/src/main.rs:static_map}}
 ```
 
 ## Gameplay
@@ -97,14 +97,14 @@ Let's modify the run function and check the colour of the spot and the box match
 
 ```rust
 // gameplay_state_system.rs.rs
-{{#include ../code/rust-sokoban-c03-01/src/systems/gameplay_state_system.rs:20:52}}
+{{#include ../code/rust-sokoban-c03-01/src/systems/gameplay_state_system.rs:run}}
 ```
 
 Now if you compile the code at this point it should complain about the fact that we are trying to compare two enums with `==`. Rust doesn't know by default how to handle this, so we must tell it. The best way we can do that is add an implementation for the `PartialEq` trait.
 
 ```rust
 // components.rs
-{{#include ../code/rust-sokoban-c03-01/src/components.rs:28:32}}
+{{#include ../code/rust-sokoban-c03-01/src/components.rs:box_colour_partialeq}}
 ```
 
 Now is a good time to discuss these unusual `derive` annotations. We've used them before, but never got too deep into what they do. Derive attributes can be applied to structs or enums and they allow us to add default trait implementations to our types. For example here we are telling Rust to add the `PartialEq` default trait implementations to our `BoxColour` enum.

--- a/src/c03-02-animations.md
+++ b/src/c03-02-animations.md
@@ -53,34 +53,40 @@ Let's also add two new functions to construct the two types of renderables, eith
 
 ```rust
 // components.rs
-{{#include ../code/rust-sokoban-c03-02/src/components.rs:19:32}}
-{{#include ../code/rust-sokoban-c03-02/src/components.rs:48}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_struct}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_impl}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_new}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_end}}
 ```
 
 Next, we need a way of telling if a renderable is animated or static, which we will use in the rendering system. We could leave the paths member variable public and allow the rendering system to get the length of the paths and infer based on the length, but there is a more idiomatic way. We can add an enum for the kind of renderable, and add a method on the renderable to get that kind, in this way we encapsulate the logic of the kind within the renderable, and we can keep paths private. You can put the kind declaration anywhere in the components.rs, but ideally next to the renderable declaration.
 
 ```rust
 // components.rs
-{{#include ../code/rust-sokoban-c03-02/src/components.rs:14:18}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_kind}}
 ```
 
 Now let's add a function to tell us the kind of a renderable based on the internal paths.
 
 ```rust
 // components.rs
-{{#include ../code/rust-sokoban-c03-02/src/components.rs:25:40}}
-{{#include ../code/rust-sokoban-c03-02/src/components.rs:48}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_impl}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_new}}
+
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_kind_impl}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_end}}
 ```
 
 And finally, because we made paths private, we need to allow users of renderable to get a specific path from our list. For static renderables, this will be the 0th path (the only one) and for animated paths we'll let the rendering system decide which path should be rendered based on the time. The only tricky bit here is if we get asked for a frame bigger than what we have, we will wrap that around by modding with the length. 
 
 ```rust
 // components.rs
-{{#include ../code/rust-sokoban-c03-02/src/components.rs:25}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_impl}}
 
     //...
 
-{{#include ../code/rust-sokoban-c03-02/src/components.rs:42:48}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_path}}
+{{#include ../code/rust-sokoban-c03-02/src/components.rs:renderable_end}}
 ```
 
 ## Entity creation
@@ -88,14 +94,14 @@ Next up, let's update our player entity creation to account for multiple paths. 
 
 ```rust
 // entities.rs
-{{#include ../code/rust-sokoban-c03-02/src/entities.rs:48:60}}
+{{#include ../code/rust-sokoban-c03-02/src/entities.rs:create_player}}
 ```
 
 And let's update everything else to use the `new_static` function - here is how we are doing it for the wall entity creation, feel free to go ahead and apply this to the other static entities.
 
 ```rust
 // entities.rs
-{{#include ../code/rust-sokoban-c03-02/src/entities.rs:5:14}}
+{{#include ../code/rust-sokoban-c03-02/src/entities.rs:create_wall}}
 ```
 
 ## Time
@@ -109,21 +115,26 @@ Let's now add a resource for time, this doesn't fit into our component model sin
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c03-02/src/resources.rs:45:48}}
+{{#include ../code/rust-sokoban-c03-02/src/resources.rs:time_struct}}
 ```
 
 And don't forget to register the new resource.
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c03-02/src/resources.rs:12:16}}
+{{#include ../code/rust-sokoban-c03-02/src/resources.rs:register_resources}}
 ```
 
 And now let's update this time in our main loop. Luckily ggez provides a function to get the delta, so all we have to do is accumulate it.
 
 ```rust
 // main.rs
-{{#include ../code/rust-sokoban-c03-02/src/main.rs:24:45}}
+{{#include ../code/rust-sokoban-c03-02/src/main.rs:event_handler_impl}}
+{{#include ../code/rust-sokoban-c03-02/src/main.rs:update}}
+
+    // ..
+
+{{#include ../code/rust-sokoban-c03-02/src/main.rs:event_handler_end}}
 ```
 
 
@@ -134,25 +145,29 @@ Let's first add a function to enapsulate this logic of getting the correct image
 
 ```rust
 // rendering_system.rs
-{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:13}}
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:rendering_system_impl}}
     //...
-{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:34:54}}
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:get_image}}
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:rendering_system_end}}
 ```
 
 And finally, let's use the new `get_image` function inside the run function (we will also have to add time to the `SystemData` definition and a couple of imports, but that should be pretty much it).
 
 ```rust
 // rendering_system.rs
-{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:57:81}}
-
-            //...
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:system_impl}}
             
-{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:88}}
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:run_1}}
 
-        //...
+        // ...
 
-{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:97}}
-{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:98}}
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:run_for}}
+
+            // ...
+
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:run_for_end}}
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:run_end}}
+{{#include ../code/rust-sokoban-c03-02/src/systems/rendering_system.rs:system_impl_end}}
 
 ```
 

--- a/src/c03-03-sounds-events.md
+++ b/src/c03-03-sounds-events.md
@@ -24,14 +24,14 @@ Let's look at our events enum.
 
 ```rust
 // events.rs
-{{#include ../code/rust-sokoban-c03-03/src/events.rs:13:23}}
+{{#include ../code/rust-sokoban-c03-03/src/events.rs:event_enum}}
 ```
 
 Note the second `EntityMoved` and the second `BoxPlacedOnSpot`. Those are actually struct definitions where we can attach properties. Let's look at those structs now.
 
 ```rust
 // events.rs
-{{#include ../code/rust-sokoban-c03-03/src/events.rs:1:11}}
+{{#include ../code/rust-sokoban-c03-03/src/events.rs:structs}}
 ```
 
 ## Event queue resource
@@ -39,29 +39,50 @@ Now let's add a resource for the event queue. We will have various systems writi
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c03-03/src/resources.rs:54:57}}
+{{#include ../code/rust-sokoban-c03-03/src/resources.rs:event_queue}}
 ```
 
 And as always let's register this resource.
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c03-03/src/resources.rs:14:18}}
-{{#include ../code/rust-sokoban-c03-03/src/resources.rs:20}}
+{{#include ../code/rust-sokoban-c03-03/src/resources.rs:register_resources_1}}
+{{#include ../code/rust-sokoban-c03-03/src/resources.rs:register_resources_end}}
 ```
 
 ## Sending events
-Now that we have a way to enqueue events, let's add the two events we need in the input_system: EntityMoved and PlayerHitObstacle.
+Now that we have a way to enqueue events, let's add the two events we need in the input_system: EntityMoved and PlayerHitObstacle. First we'll need to import our event enum with the rest of our includes:
 
 ```rust
 // input_system.rs
-{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:1:42}}
-                    // ...
-                    // ...
-{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:83:124}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:includes}}
 ```
 
-I've omitted some of the code in the original file for readability, but we are really just adding two lines in the right places. 
+Then we'll want to tell specs to give us access to the event queue:
+
+```rust
+// input_system.rs
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:input_system_start}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:input_system_data}}
+
+    // ...
+    
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:run_start}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:run_let_data}}
+
+        // ...
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:run_end}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:input_system_end}}
+```
+
+Finally, we need to actually put some events into the queue! Add these two lines:
+
+```rust
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:immov_match}}
+```
+```rust
+{{#include ../code/rust-sokoban-c03-03/src/systems/input_system.rs:input_system_for_act}}
+```
 
 ## Consuming events - event system
 Now it's time to add a way to consume the events, which will be the events system. This system will contain the logic for what should happen when a specific event is received.
@@ -73,10 +94,21 @@ Let discuss how we will handle each event:
 
 ```rust
 // event_system.rs
-{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:1:34}}
-{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:36:63}}
-{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:71:78}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:include_start}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:include_end}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:event_sys_impl_start}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:sys_data_1}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:sys_data_2}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:run_start}}
+        let (mut event_queue, entities, boxes, box_spots, positions) = data;
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:run_body_1}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:run_body_2}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:run_body_3}}
+```
 
+`systems/mod.rs` needs to be updated:
+```rust
+{{#include ../code/rust-sokoban-c03-03/src/systems/mod.rs:}}
 ```
 
 ## Audio assets
@@ -120,41 +152,89 @@ We'll use a resource for the audio store.
 
 ```rust
 // audio.rs
-{{#include ../code/rust-sokoban-c03-03/src/audio.rs:6:9}}
+{{#include ../code/rust-sokoban-c03-03/src/audio.rs:audio_store_struct}}
 ```
 
 And as always let's register this resource.
 
 ```rust
 // resources.rs
-{{#include ../code/rust-sokoban-c03-03/src/resources.rs:14:20}}
+{{#include ../code/rust-sokoban-c03-03/src/resources.rs:register_resources_1}}
+{{#include ../code/rust-sokoban-c03-03/src/resources.rs:register_resources_2}}
+{{#include ../code/rust-sokoban-c03-03/src/resources.rs:register_resources_end}}
 ```
 
 And let's add the code for initializing the store.
 
 ```rust
 // audio.rs
-{{#include ../code/rust-sokoban-c03-03/src/audio.rs:21:32}}
+{{#include ../code/rust-sokoban-c03-03/src/audio.rs:initialize_sounds}}
 ```
 
-## Playing audio
-Finally, let's add the ability to play the sound in the store.
+In `main.rs` too.
 
 ```rust
 // audio.rs
-{{#include ../code/rust-sokoban-c03-03/src/audio.rs:11:19}}
+{{#include ../code/rust-sokoban-c03-03/src/main.rs:mods}}
+
+// ...
+
+{{#include ../code/rust-sokoban-c03-03/src/main.rs:event_handler_start}}
+        // ..
+
+{{#include ../code/rust-sokoban-c03-03/src/main.rs:event_sys}}
+{{#include ../code/rust-sokoban-c03-03/src/main.rs:event_handler_end}}
+
+// ..
+
+{{#include ../code/rust-sokoban-c03-03/src/main.rs:main_start}}
+    // ...
+
+{{#include ../code/rust-sokoban-c03-03/src/main.rs:init_sounds}}
+
+    // ...
+{{#include ../code/rust-sokoban-c03-03/src/main.rs:main_end}}
+
 ```
 
-And now let's play in the event system.
+## Playing audio
+Let's add the ability to play the sound in the store.
 
 ```rust
-    // event_system.rs
-{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:24:37}}
-                        // ...
-{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:61:73}}
+// audio.rs
+{{#include ../code/rust-sokoban-c03-03/src/audio.rs:audio_store_impl}}
 ```
 
-Now let's run the game and enjoy those sound effects!
+Import the audio store into the event system.
+
+```rust
+// event_system.rs
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:include_start}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:include_audio_store}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:include_end}}
+
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:event_sys_impl_start}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:sys_data_1}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:sys_data_audio}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:sys_data_2}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:run_start}}
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:run_let_data}}
+
+        // ..
+
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:run_end}}
+```
+
+Update the event system to play sounds.
+
+```rust
+            // event_system.rs
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:play_sound_1}}
+                    // ...
+{{#include ../code/rust-sokoban-c03-03/src/systems/event_system.rs:play_sound_2}}
+```
+
+It's been a long chapter, but you can finally play the game and enjoy those sound effects!
 
 <video width="75%" controls>
     <source src="./videos/audio.mov" type="video/mp4">


### PR DESCRIPTION
This pull request switches the code include statements to using anchors instead of line numbers. There are a couple of other minor tweaks to the tutorial to try and clarify some bits I thought were confusing. Once merged, this pull implements the anchor part of #46, no attempt has been made to use diffs yet.