### PR TITLE
Add caching

### DIFF
--- a/.github/workflows/code-samples-compile.yml
+++ b/.github/workflows/code-samples-compile.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: ${{ matrix.sample_path }}
       - run: sudo apt-get install libudev-dev libasound2-dev
       - name: Build ${{ matrix.sample_path }}
         run: cd ${{ matrix.sample_path }} && cargo check


### PR DESCRIPTION
I don't think we can do smarter cache across the folders, because I think the jobs run in parallel. I think we could run them in a single job and share a `target` dir or something, but at least this cache action should help consecutive compiles.

Relates to https://github.com/iolivia/rust-sokoban/issues/13