### PR TITLE
Fix wrong chapter code reference for cargo.toml in c01-04

### DIFF
--- a/books/en_US/src/c01-04-rendering.md
+++ b/books/en_US/src/c01-04-rendering.md
@@ -34,7 +34,7 @@ Running the game now should compile, but it will probably not do anything yet, s
 **Note:** We're going to add [glam](https://lib.rs/crates/glam) as a dependency here that is a simple and fast 3D library that offers some performance improvements.
 
 ```
-{{#include ../../../code/rust-sokoban-c01-03/Cargo.toml:9:11}}
+{{#include ../../../code/rust-sokoban-c01-04/Cargo.toml:9:11}}
 ```
 
 Here is the implementation of the rendering system. It does a few things:


### PR DESCRIPTION
| Before | After |
| --------------- | --------------- |
| ![2022-06-12_15-39](https://user-images.githubusercontent.com/1086461/173236146-513f2cdb-2824-49b1-a429-9079063a4138.png) | ![2022-06-12_15-42](https://user-images.githubusercontent.com/1086461/173236156-78cd77a8-985f-4914-be70-ba9f04567af7.png) |
 