### PR TITLE
fix: correct initial game state from 'Won' to 'Playing'

### DIFF
--- a/code/rust-sokoban-c03-01/src/systems/gameplay.rs
+++ b/code/rust-sokoban-c03-01/src/systems/gameplay.rs
@@ -24,7 +24,7 @@ pub fn run_gameplay_state(world: &World) {
                     1
                 }
             } else {
-                0
+                1
             }
         })
         .collect::<Vec<usize>>()

--- a/code/rust-sokoban-c03-02/src/systems/gameplay.rs
+++ b/code/rust-sokoban-c03-02/src/systems/gameplay.rs
@@ -24,7 +24,7 @@ pub fn run_gameplay_state(world: &World) {
                     1
                 }
             } else {
-                0
+                1
             }
         })
         .collect::<Vec<usize>>()

--- a/code/rust-sokoban-c03-03/src/systems/gameplay.rs
+++ b/code/rust-sokoban-c03-03/src/systems/gameplay.rs
@@ -24,7 +24,7 @@ pub fn run_gameplay_state(world: &World) {
                     1
                 }
             } else {
-                0
+                1
             }
         })
         .collect::<Vec<usize>>()

--- a/code/rust-sokoban-c03-04/src/systems/gameplay.rs
+++ b/code/rust-sokoban-c03-04/src/systems/gameplay.rs
@@ -24,7 +24,7 @@ pub fn run_gameplay_state(world: &World) {
                     1
                 }
             } else {
-                0
+                1
             }
         })
         .collect::<Vec<usize>>()

--- a/code/rust-sokoban-c03-05/src/systems/gameplay.rs
+++ b/code/rust-sokoban-c03-05/src/systems/gameplay.rs
@@ -24,7 +24,7 @@ pub fn run_gameplay_state(world: &World) {
                     1
                 }
             } else {
-                0
+                1
             }
         })
         .collect::<Vec<usize>>()


### PR DESCRIPTION
fix: correct initial game state from 'Won' to 'Playing'

- The initial state was incorrectly set to 'Won', causing the game to appear completed at the start.
- Changed the default state to 'Playing' to ensure the game starts in the correct state.